### PR TITLE
feat(seo): full SEO metadata audit — 임주해 전 라우트 메타데이터 주입

### DIFF
--- a/app/landlord/layout.tsx
+++ b/app/landlord/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '집주인 대시보드',
+  description: '임주해(Rentme) 집주인 대시보드에서 매물을 관리하고 신뢰할 수 있는 세입자를 찾아보세요. 세입자 프로필 기반 부동산 매칭 플랫폼.',
+  openGraph: {
+    title: '집주인 대시보드 | 임주해',
+    description: '임주해(Rentme) 집주인 대시보드에서 매물을 관리하고 신뢰할 수 있는 세입자를 찾아보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 집주인 대시보드' }],
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function LandlordLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,9 +7,36 @@ import './globals.css'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: '입주해 - 좋은 세입자임을 증명하세요',
-  description: '세입자 프로필을 생성하고 집주인에게 신뢰를 전달하세요.',
-  keywords: ['세입자', '임대', '프로필', '자기소개서', '집주인', '입주'],
+  title: {
+    default: '임주해 - 좋은 세입자임을 증명하세요',
+    template: '%s | 임주해',
+  },
+  description: '세입자 프로필을 생성하고 집주인에게 신뢰를 전달하세요. 임주해는 세입자 프로필 기반 부동산 매칭 플랫폼입니다.',
+  keywords: ['세입자', '임대', '프로필', '자기소개서', '집주인', '입주', '부동산', '매칭', '임주해', 'Rentme'],
+  openGraph: {
+    type: 'website',
+    siteName: '임주해 (Rentme)',
+    title: '임주해 - 좋은 세입자임을 증명하세요',
+    description: '세입자 프로필을 생성하고 집주인에게 신뢰를 전달하세요. 임주해는 세입자 프로필 기반 부동산 매칭 플랫폼입니다.',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: '임주해 - 세입자 프로필 기반 부동산 매칭 플랫폼',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: '임주해 - 좋은 세입자임을 증명하세요',
+    description: '세입자 프로필을 생성하고 집주인에게 신뢰를 전달하세요.',
+    images: ['/og-image.png'],
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 }
 
 export default function RootLayout({

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '로그인',
+  description: '임주해(Rentme)에 로그인하세요. 세입자 프로필 기반 부동산 매칭 플랫폼에서 집주인과 세입자를 연결합니다.',
+  openGraph: {
+    title: '로그인 | 임주해',
+    description: '임주해(Rentme)에 로그인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 로그인' }],
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/messages/layout.tsx
+++ b/app/messages/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '메시지',
+  description: '임주해(Rentme) 메시지 센터에서 집주인과 세입자 간의 대화를 확인하세요.',
+  openGraph: {
+    title: '메시지 | 임주해',
+    description: '임주해(Rentme) 메시지 센터에서 집주인과 세입자 간의 대화를 확인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 메시지' }],
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function MessagesLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/onboarding/layout.tsx
+++ b/app/onboarding/layout.tsx
@@ -1,5 +1,20 @@
+import type { Metadata } from 'next'
 import { Home } from 'lucide-react'
 import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: '프로필 설정',
+  description: '임주해(Rentme)에서 세입자 프로필을 만들어보세요. 기본 정보와 생활 패턴을 입력하면 신뢰할 수 있는 세입자임을 집주인에게 증명할 수 있습니다.',
+  openGraph: {
+    title: '프로필 설정 | 임주해',
+    description: '임주해(Rentme)에서 세입자 프로필을 만들어보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 프로필 설정' }],
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default function OnboardingLayout({
   children,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 import { Hero } from '@/components/landing/hero'
 import { FeaturesSection } from '@/components/landing/features-section'
 import { HowItWorks } from '@/components/landing/how-it-works'
@@ -5,6 +6,16 @@ import { StatsSection } from '@/components/landing/stats-section'
 import { CtaSection } from '@/components/landing/cta-section'
 import { Footer } from '@/components/landing/footer'
 import { Header } from '@/components/layout/header'
+
+export const metadata: Metadata = {
+  title: '임주해 - 세입자 프로필 기반 부동산 매칭 플랫폼',
+  description: '임주해(Rentme)에서 세입자 프로필을 만들고 신뢰를 증명하세요. 집주인과 세입자를 연결하는 스마트 부동산 매칭 플랫폼.',
+  openGraph: {
+    title: '임주해 - 세입자 프로필 기반 부동산 매칭 플랫폼',
+    description: '임주해(Rentme)에서 세입자 프로필을 만들고 신뢰를 증명하세요. 집주인과 세입자를 연결하는 스마트 부동산 매칭 플랫폼.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 랜딩 페이지' }],
+  },
+}
 
 export default function HomePage() {
   return (

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,4 +1,19 @@
+import type { Metadata } from 'next'
 import { Header } from '@/components/layout/header'
+
+export const metadata: Metadata = {
+  title: '개인정보처리방침',
+  description: '임주해(Rentme)의 개인정보처리방침을 확인하세요. 세입자 프로필 기반 부동산 매칭 플랫폼 임주해가 수집·이용하는 개인정보와 보호 정책을 안내합니다.',
+  openGraph: {
+    title: '개인정보처리방침 | 임주해',
+    description: '임주해(Rentme)의 개인정보처리방침을 확인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 개인정보처리방침' }],
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default function PrivacyPage() {
   return (

--- a/app/profile/[id]/layout.tsx
+++ b/app/profile/[id]/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '세입자 프로필',
+  description: '임주해(Rentme)에서 세입자 프로필을 확인하세요. 신뢰점수와 인증 정보를 통해 믿을 수 있는 세입자를 만나보세요.',
+  openGraph: {
+    title: '세입자 프로필 | 임주해',
+    description: '임주해(Rentme)에서 세입자 프로필을 확인하세요. 신뢰점수와 인증 정보를 통해 믿을 수 있는 세입자를 만나보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 세입자 프로필' }],
+  },
+}
+
+export default function PublicProfileLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '내 프로필',
+  description: '임주해(Rentme)에서 내 세입자 프로필을 확인하고 관리하세요. 신뢰점수, 인증 정보, 레퍼런스를 한눈에 볼 수 있습니다.',
+  openGraph: {
+    title: '내 프로필 | 임주해',
+    description: '임주해(Rentme)에서 내 세입자 프로필을 확인하고 관리하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 세입자 프로필' }],
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function ProfileLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/reference/survey/layout.tsx
+++ b/app/reference/survey/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '집주인 레퍼런스 설문',
+  description: '임주해(Rentme) 집주인 레퍼런스 설문에 참여해주세요. 세입자의 신뢰점수 향상에 도움이 됩니다.',
+  openGraph: {
+    title: '집주인 레퍼런스 설문 | 임주해',
+    description: '임주해(Rentme) 집주인 레퍼런스 설문에 참여해주세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 레퍼런스 설문' }],
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function SurveyLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/signup/layout.tsx
+++ b/app/signup/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '회원가입',
+  description: '임주해(Rentme)에 가입하고 세입자 프로필을 만들어보세요. 세입자 프로필 기반 부동산 매칭 플랫폼에서 신뢰할 수 있는 세입자임을 증명하세요.',
+  openGraph: {
+    title: '회원가입 | 임주해',
+    description: '임주해(Rentme)에 가입하고 세입자 프로필을 만들어보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 회원가입' }],
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function SignupLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,4 +1,19 @@
+import type { Metadata } from 'next'
 import { Header } from '@/components/layout/header'
+
+export const metadata: Metadata = {
+  title: '이용약관',
+  description: '임주해(Rentme) 서비스 이용약관을 확인하세요. 세입자 프로필 기반 부동산 매칭 플랫폼 임주해의 서비스 이용 조건 및 정책을 안내합니다.',
+  openGraph: {
+    title: '이용약관 | 임주해',
+    description: '임주해(Rentme) 서비스 이용약관을 확인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 이용약관' }],
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default function TermsPage() {
   return (

--- a/app/verify-phone/layout.tsx
+++ b/app/verify-phone/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '휴대폰 인증',
+  description: '임주해(Rentme) 본인 확인을 위해 휴대폰 번호를 인증해주세요. 인증 완료 시 신뢰점수가 향상됩니다.',
+  openGraph: {
+    title: '휴대폰 인증 | 임주해',
+    description: '임주해(Rentme) 본인 확인을 위해 휴대폰 번호를 인증해주세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 휴대폰 인증' }],
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function VerifyPhoneLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary

- 31개 파일 (page.tsx / layout.tsx) SEO 메타데이터 전수 감사 완료
- app/layout.tsx 루트 레이아웃에 openGraph, twitter card, robots, 타이틀 템플릿 패턴 추가
- 서버 컴포넌트 페이지(terms, privacy, onboarding layout, landing) 직접 metadata export 추가
- 'use client' 페이지 전용 경로에 8개 신규 layout.tsx 생성하여 페이지별 메타데이터 적용
- 모든 경로에 og:image '/og-image.png' 기본값 설정
- 인증/대시보드 페이지는 robots: { index: false } 처리

## Changed Files

| 파일 | 변경 유형 | 내용 |
|------|-----------|------|
| app/layout.tsx | 수정 | openGraph, twitter, robots, 타이틀 템플릿 추가 |
| app/page.tsx | 수정 | 랜딩 페이지 metadata export 추가 |
| app/terms/page.tsx | 수정 | 이용약관 metadata (noindex) |
| app/privacy/page.tsx | 수정 | 개인정보처리방침 metadata (noindex) |
| app/onboarding/layout.tsx | 수정 | 온보딩 메타데이터 (noindex) |
| app/login/layout.tsx | 신규 | 로그인 페이지 메타데이터 (noindex) |
| app/signup/layout.tsx | 신규 | 회원가입 페이지 메타데이터 (noindex) |
| app/profile/layout.tsx | 신규 | 프로필 관리 메타데이터 (noindex) |
| app/profile/[id]/layout.tsx | 신규 | 공개 세입자 프로필 메타데이터 (index) |
| app/messages/layout.tsx | 신규 | 메시지 센터 메타데이터 (noindex) |
| app/landlord/layout.tsx | 신규 | 집주인 대시보드 메타데이터 (noindex) |
| app/verify-phone/layout.tsx | 신규 | 휴대폰 인증 메타데이터 (noindex) |
| app/reference/survey/layout.tsx | 신규 | 레퍼런스 설문 메타데이터 (noindex) |

## Metadata Guidelines Applied

- Site name: 임주해 (Rentme)
- Description theme: 세입자 프로필 기반 부동산 매칭 플랫폼
- API: Next.js 14 Metadata API (export const metadata: Metadata)
- og:image: /og-image.png (기본값, 1200x630)
- Title template: %s | 임주해 (루트 layout 기준)
- 'use client' 처리: 클라이언트 컴포넌트는 상위 layout.tsx 를 통해 메타데이터 적용

## Test Plan

- [ ] app/page.tsx — 랜딩 페이지 OG 태그 확인
- [ ] app/profile/[id]/page.tsx — 공개 프로필 페이지 title/description 렌더 확인
- [ ] app/terms/page.tsx — noindex robots 메타태그 확인
- [ ] next build 정상 완료 확인
- [ ] head 내 og:image, og:title, og:description 포함 여부 확인

Generated with Claude Code (claude-sonnet-4-6)
