### PR TITLE
test: improve coverage for date and verification modules

### DIFF
--- a/__tests__/lib/date.test.ts
+++ b/__tests__/lib/date.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  formatDistanceToNow,
+  formatDate,
+  formatDateTime,
+  formatTime,
+  isToday,
+  formatMessageDate,
+} from '@/lib/date'
+
+describe('formatDistanceToNow', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('방금 전 - 60초 미만', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00Z')
+    vi.setSystemTime(now)
+    const recent = new Date('2024-06-15T11:59:45Z') // 15초 전
+    expect(formatDistanceToNow(recent)).toBe('방금 전')
+  })
+
+  it('방금 전 - Date 문자열도 지원', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00Z')
+    vi.setSystemTime(now)
+    const recent = '2024-06-15T11:59:50Z' // 10초 전
+    expect(formatDistanceToNow(recent)).toBe('방금 전')
+  })
+
+  it('N분 전 - 60분 미만', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00Z')
+    vi.setSystemTime(now)
+    const fiveMinAgo = new Date('2024-06-15T11:55:00Z')
+    expect(formatDistanceToNow(fiveMinAgo)).toBe('5분 전')
+  })
+
+  it('N분 전 - 59분', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00Z')
+    vi.setSystemTime(now)
+    const fiftyNineMinAgo = new Date('2024-06-15T11:01:00Z')
+    expect(formatDistanceToNow(fiftyNineMinAgo)).toBe('59분 전')
+  })
+
+  it('N시간 전 - 24시간 미만', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00Z')
+    vi.setSystemTime(now)
+    const threeHoursAgo = new Date('2024-06-15T09:00:00Z')
+    expect(formatDistanceToNow(threeHoursAgo)).toBe('3시간 전')
+  })
+
+  it('N일 전 - 7일 미만', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00Z')
+    vi.setSystemTime(now)
+    const threeDaysAgo = new Date('2024-06-12T12:00:00Z')
+    expect(formatDistanceToNow(threeDaysAgo)).toBe('3일 전')
+  })
+
+  it('N주 전 - 4주 미만', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00Z')
+    vi.setSystemTime(now)
+    const twoWeeksAgo = new Date('2024-06-01T12:00:00Z')
+    expect(formatDistanceToNow(twoWeeksAgo)).toBe('2주 전')
+  })
+
+  it('N개월 전 - 12개월 미만', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00Z')
+    vi.setSystemTime(now)
+    const threeMonthsAgo = new Date('2024-03-15T12:00:00Z') // ~91일
+    expect(formatDistanceToNow(threeMonthsAgo)).toBe('3개월 전')
+  })
+
+  it('N년 전 - 1년 이상', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00Z')
+    vi.setSystemTime(now)
+    const twoYearsAgo = new Date('2022-06-15T12:00:00Z')
+    expect(formatDistanceToNow(twoYearsAgo)).toBe('2년 전')
+  })
+})
+
+describe('formatDate', () => {
+  it('날짜 객체를 한국어 형식으로 포맷', () => {
+    const date = new Date('2024-01-15T00:00:00')
+    const result = formatDate(date)
+    // 로케일 포맷 검증 - '2024'와 '1'과 '15'를 포함해야 함
+    expect(result).toContain('2024')
+    expect(result).toContain('1')
+    expect(result).toContain('15')
+  })
+
+  it('날짜 문자열도 지원', () => {
+    const result = formatDate('2024-06-15')
+    expect(result).toContain('2024')
+    expect(result).toContain('6')
+    expect(result).toContain('15')
+  })
+
+  it('반환값이 문자열', () => {
+    expect(typeof formatDate(new Date())).toBe('string')
+  })
+})
+
+describe('formatDateTime', () => {
+  it('날짜와 시간을 한국어 형식으로 포맷', () => {
+    const date = new Date('2024-01-15T15:30:00')
+    const result = formatDateTime(date)
+    expect(result).toContain('2024')
+    expect(result).toContain('1')
+    expect(result).toContain('15')
+  })
+
+  it('날짜 문자열도 지원', () => {
+    const result = formatDateTime('2024-06-15T10:00:00')
+    expect(result).toContain('2024')
+    expect(typeof result).toBe('string')
+  })
+
+  it('반환값이 문자열', () => {
+    expect(typeof formatDateTime(new Date())).toBe('string')
+  })
+})
+
+describe('formatTime', () => {
+  it('시간을 한국어 형식으로 포맷', () => {
+    const date = new Date('2024-01-15T15:30:00')
+    const result = formatTime(date)
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  it('날짜 문자열도 지원', () => {
+    const result = formatTime('2024-06-15T09:05:00')
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+})
+
+describe('isToday', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('오늘 날짜는 true 반환', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T10:00:00')
+    vi.setSystemTime(now)
+    expect(isToday(new Date('2024-06-15T08:00:00'))).toBe(true)
+  })
+
+  it('오늘 자정 직후도 true 반환', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T23:59:00')
+    vi.setSystemTime(now)
+    expect(isToday(new Date('2024-06-15T00:01:00'))).toBe(true)
+  })
+
+  it('어제 날짜는 false 반환', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T10:00:00')
+    vi.setSystemTime(now)
+    expect(isToday(new Date('2024-06-14T10:00:00'))).toBe(false)
+  })
+
+  it('내일 날짜는 false 반환', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T10:00:00')
+    vi.setSystemTime(now)
+    expect(isToday(new Date('2024-06-16T10:00:00'))).toBe(false)
+  })
+
+  it('다른 연도는 false 반환', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T10:00:00')
+    vi.setSystemTime(now)
+    expect(isToday(new Date('2023-06-15T10:00:00'))).toBe(false)
+  })
+
+  it('날짜 문자열도 지원', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T10:00:00')
+    vi.setSystemTime(now)
+    expect(isToday('2024-06-15T10:00:00')).toBe(true)
+    expect(isToday('2024-06-14T10:00:00')).toBe(false)
+  })
+})
+
+describe('formatMessageDate', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('오늘 메시지는 시간만 표시', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00')
+    vi.setSystemTime(now)
+    const todayMsg = new Date('2024-06-15T09:30:00')
+    const result = formatMessageDate(todayMsg)
+    // formatTime과 동일한 결과여야 함
+    expect(result).toBe(formatTime(todayMsg))
+  })
+
+  it('오늘이 아닌 메시지는 날짜 표시', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00')
+    vi.setSystemTime(now)
+    const oldMsg = new Date('2024-06-10T09:30:00')
+    const result = formatMessageDate(oldMsg)
+    // formatDate와 동일한 결과여야 함
+    expect(result).toBe(formatDate(oldMsg))
+  })
+
+  it('어제 메시지는 날짜를 포함', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00')
+    vi.setSystemTime(now)
+    const yesterday = new Date('2024-06-14T10:00:00')
+    const result = formatMessageDate(yesterday)
+    expect(result).toContain('2024')
+    expect(result).toContain('6')
+    expect(result).toContain('14')
+  })
+
+  it('날짜 문자열도 지원', () => {
+    vi.useFakeTimers()
+    const now = new Date('2024-06-15T12:00:00')
+    vi.setSystemTime(now)
+    const result = formatMessageDate('2024-06-15T08:00:00')
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+})

--- a/__tests__/lib/verification.test.ts
+++ b/__tests__/lib/verification.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  verifyEmployment,
+  verifyIncome,
+  verifyCredit,
+  verifyIdentity,
+  getVerificationProvider,
+} from '@/lib/verification'
+
+// Mock logger to suppress output during tests
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+describe('getVerificationProvider', () => {
+  it('기본값은 mock 프로바이더', () => {
+    // VERIFICATION_PROVIDER 환경변수가 없으면 mock 반환
+    const provider = getVerificationProvider()
+    expect(['mock', 'codef', 'nice']).toContain(provider)
+  })
+})
+
+// 모든 테스트는 VERIFICATION_PROVIDER=mock 환경에서 실행
+describe('verifyEmployment (mock provider)', () => {
+  beforeEach(() => {
+    // mock provider 강제 설정 - 환경변수가 없으면 mock이 기본값
+    vi.stubEnv('VERIFICATION_PROVIDER', 'mock')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('회사명으로 재직 인증 성공', async () => {
+    const result = await verifyEmployment('삼성전자')
+
+    expect(result.success).toBe(true)
+    expect(result.data).toBeDefined()
+    expect(result.data?.verified).toBe(true)
+    expect(result.data?.company).toBe('삼성전자')
+  }, 2000)
+
+  it('회사명이 결과 데이터에 포함됨', async () => {
+    const companyName = '카카오'
+    const result = await verifyEmployment(companyName)
+
+    expect(result.success).toBe(true)
+    expect(result.data?.company).toBe(companyName)
+  }, 2000)
+
+  it('입사일 정보가 포함됨', async () => {
+    const result = await verifyEmployment('네이버')
+
+    expect(result.success).toBe(true)
+    expect(result.data?.joinDate).toBeDefined()
+    expect(typeof result.data?.joinDate).toBe('string')
+  }, 2000)
+
+  it('userIdentity 없어도 mock에서는 성공', async () => {
+    const result = await verifyEmployment('LG전자', undefined)
+
+    expect(result.success).toBe(true)
+  }, 2000)
+})
+
+describe('verifyIncome (mock provider)', () => {
+  beforeEach(() => {
+    vi.stubEnv('VERIFICATION_PROVIDER', 'mock')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('소득 범위로 소득 인증 성공', async () => {
+    const result = await verifyIncome('3000만원~5000만원')
+
+    expect(result.success).toBe(true)
+    expect(result.data).toBeDefined()
+    expect(result.data?.verified).toBe(true)
+  }, 2000)
+
+  it('소득 범위가 결과에 포함됨', async () => {
+    const incomeRange = '5000만원~7000만원'
+    const result = await verifyIncome(incomeRange)
+
+    expect(result.success).toBe(true)
+    expect(result.data?.incomeRange).toBe(incomeRange)
+  }, 2000)
+
+  it('userIdentity 없어도 mock에서는 성공', async () => {
+    const result = await verifyIncome('3000만원 미만', undefined)
+
+    expect(result.success).toBe(true)
+  }, 2000)
+
+  it('다양한 소득 범위에 대해 성공', async () => {
+    const ranges = ['3000만원 미만', '3000만원~5000만원', '5000만원~7000만원', '7000만원 이상']
+    for (const range of ranges) {
+      const result = await verifyIncome(range)
+      expect(result.success).toBe(true)
+      expect(result.data?.incomeRange).toBe(range)
+    }
+  }, 5000)
+})
+
+describe('verifyCredit (mock provider)', () => {
+  beforeEach(() => {
+    vi.stubEnv('VERIFICATION_PROVIDER', 'mock')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('신용 인증 성공', async () => {
+    const result = await verifyCredit()
+
+    expect(result.success).toBe(true)
+    expect(result.data).toBeDefined()
+    expect(result.data?.verified).toBe(true)
+  }, 2000)
+
+  it('신용 등급이 숫자로 반환됨', async () => {
+    const result = await verifyCredit()
+
+    expect(result.success).toBe(true)
+    expect(typeof result.data?.creditGrade).toBe('number')
+    expect(result.data?.creditGrade).toBeGreaterThanOrEqual(1)
+    expect(result.data?.creditGrade).toBeLessThanOrEqual(3) // mock은 1-3 범위
+  }, 2000)
+
+  it('등급 레이블이 포함됨', async () => {
+    const result = await verifyCredit()
+
+    expect(result.success).toBe(true)
+    expect(typeof result.data?.gradeLabel).toBe('string')
+    expect(result.data?.gradeLabel.length).toBeGreaterThan(0)
+    expect(['최우량', '양호', '보통']).toContain(result.data?.gradeLabel)
+  }, 2000)
+
+  it('userIdentity 없어도 mock에서는 성공', async () => {
+    const result = await verifyCredit(undefined)
+
+    expect(result.success).toBe(true)
+  }, 2000)
+})
+
+describe('verifyIdentity (mock provider)', () => {
+  beforeEach(() => {
+    vi.stubEnv('VERIFICATION_PROVIDER', 'mock')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('본인 인증 성공', async () => {
+    const result = await verifyIdentity('홍길동', '010-1234-5678', '1990-01-15')
+
+    expect(result.success).toBe(true)
+    expect(result.data).toBeDefined()
+    expect(result.data?.verified).toBe(true)
+  }, 2000)
+
+  it('이름이 결과에 포함됨', async () => {
+    const name = '김철수'
+    const result = await verifyIdentity(name, '010-9876-5432', '1985-05-20')
+
+    expect(result.success).toBe(true)
+    expect(result.data?.name).toBe(name)
+  }, 2000)
+
+  it('생년월일이 결과에 포함됨', async () => {
+    const birthDate = '1992-03-10'
+    const result = await verifyIdentity('이영희', '010-1111-2222', birthDate)
+
+    expect(result.success).toBe(true)
+    expect(result.data?.birthDate).toBe(birthDate)
+  }, 2000)
+
+  it('전화번호가 결과에 포함됨', async () => {
+    const phoneNumber = '010-5555-6666'
+    const result = await verifyIdentity('박민준', phoneNumber, '1988-07-25')
+
+    expect(result.success).toBe(true)
+    expect(result.data?.phoneNumber).toBe(phoneNumber)
+  }, 2000)
+
+  it('CI와 DI가 생성됨', async () => {
+    const result = await verifyIdentity('최수진', '010-7777-8888', '1995-12-01')
+
+    expect(result.success).toBe(true)
+    expect(typeof result.data?.ci).toBe('string')
+    expect(typeof result.data?.di).toBe('string')
+    expect(result.data?.ci).toMatch(/^mock_ci_/)
+    expect(result.data?.di).toMatch(/^mock_di_/)
+  }, 2000)
+
+  it('성별 정보가 포함됨', async () => {
+    const result = await verifyIdentity('정지훈', '010-3333-4444', '1991-08-15')
+
+    expect(result.success).toBe(true)
+    expect(typeof result.data?.gender).toBe('string')
+  }, 2000)
+})
+
+describe('verifyEmployment - result structure', () => {
+  it('성공 결과는 success: true와 data를 포함', async () => {
+    const result = await verifyEmployment('현대자동차')
+
+    expect(result).toHaveProperty('success')
+    expect(typeof result.success).toBe('boolean')
+    if (result.success) {
+      expect(result.data).toBeDefined()
+    }
+  }, 2000)
+
+  it('userIdentity 객체를 선택적으로 전달 가능', async () => {
+    const userIdentity = {
+      name: '홍길동',
+      birthDate: '1990-01-15',
+      phoneNumber: '010-1234-5678',
+    }
+    const result = await verifyEmployment('SK텔레콤', userIdentity)
+
+    expect(result.success).toBe(true)
+    expect(result.data?.company).toBe('SK텔레콤')
+  }, 2000)
+})
+
+describe('verifyIncome - result structure', () => {
+  it('성공 결과는 success: true와 data를 포함', async () => {
+    const result = await verifyIncome('7000만원 이상')
+
+    expect(result).toHaveProperty('success')
+    expect(typeof result.success).toBe('boolean')
+    if (result.success) {
+      expect(result.data).toBeDefined()
+    }
+  }, 2000)
+
+  it('userIdentity 객체를 선택적으로 전달 가능', async () => {
+    const userIdentity = {
+      name: '김철수',
+      birthDate: '1985-06-20',
+      phoneNumber: '010-9876-5432',
+    }
+    const result = await verifyIncome('5000만원~7000만원', userIdentity)
+
+    expect(result.success).toBe(true)
+    expect(result.data?.incomeRange).toBe('5000만원~7000만원')
+  }, 2000)
+})
+
+describe('verifyCredit - result structure', () => {
+  it('성공 결과는 success: true와 data를 포함', async () => {
+    const result = await verifyCredit()
+
+    expect(result).toHaveProperty('success')
+    expect(typeof result.success).toBe('boolean')
+    if (result.success) {
+      expect(result.data).toBeDefined()
+    }
+  }, 2000)
+
+  it('userIdentity 객체를 선택적으로 전달 가능', async () => {
+    const userIdentity = {
+      name: '이영희',
+      birthDate: '1992-11-30',
+      phoneNumber: '010-5555-6666',
+    }
+    const result = await verifyCredit(userIdentity)
+
+    expect(result.success).toBe(true)
+    expect(result.data?.creditGrade).toBeDefined()
+  }, 2000)
+})


### PR DESCRIPTION
## Summary

- Added unit tests for `lib/date.ts` (0% → 100% coverage)
- Added unit tests for `lib/verification.ts` (0% → 68% function coverage)
- Overall `lib/` statement coverage improved from 28% → 39%, function coverage from 18% → 48%
- All 175 tests pass (52 new tests added)

## Modules Tested

### `lib/date.ts` — 100% coverage
All 6 exported utility functions are now fully covered:
- `formatDistanceToNow` — 8 cases covering all time buckets (방금 전, N분, N시간, N일, N주, N개월, N년)
- `formatDate` — Korean locale date formatting
- `formatDateTime` — Korean locale date+time formatting
- `formatTime` — Time-only formatting
- `isToday` — Boundary cases using fake timers (today, yesterday, tomorrow, different year)
- `formatMessageDate` — Routing logic (today → time only, other days → date)

### `lib/verification.ts` — 68% function coverage
All 5 exported functions covered via mock provider:
- `verifyEmployment` — Company name propagation, joinDate presence, optional userIdentity
- `verifyIncome` — Income range propagation, all valid ranges, optional userIdentity
- `verifyCredit` — Credit grade range (1-3), grade label validation, optional userIdentity
- `verifyIdentity` — Name/birthDate/phone propagation, CI/DI generation, gender field
- `getVerificationProvider` — Returns valid provider value

## Test plan
- [x] `npx vitest run` — all 175 tests pass
- [x] `npx vitest run --coverage` — coverage output verified
- [x] No production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for date formatting utilities and verification module to ensure reliability and consistency of core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->