### PR TITLE
fix(db): correct evidence FK to trust_evidence_nodes in migration-028

### DIFF
--- a/db/migration-028-contract-report-productization.sql
+++ b/db/migration-028-contract-report-productization.sql
@@ -105,7 +105,7 @@ CREATE TABLE IF NOT EXISTS contract_check_items (
   item_key TEXT NOT NULL,
   label TEXT NOT NULL,
   verification_status TEXT NOT NULL DEFAULT 'MISSING',
-  evidence_id UUID REFERENCES trust_evidence_items(id),
+  evidence_id UUID REFERENCES trust_evidence_nodes(id),
   source_type TEXT,
   source_name TEXT,
   source_ref TEXT,


### PR DESCRIPTION
## 문제
프로덕션 DB가 마이그레이션 **027까지만** 적용된 채 028~031이 미적용 상태로 남아 있었고, 이로 인해 `/api/cron/trust-outbox`(및 관련 cron)가 스키마 드리프트 하에서 동작했습니다. `Scheduled maintenance / Dispatch trust outbox` 워크플로우가 실패한 근본 배경입니다.

## 근본원인
`db/migrate.ts`의 apply가 매번 028에서 실패:
```
[apply] migration-028-contract-report-productization.sql
[migration-error] error: relation "trust_evidence_items" does not exist (42P01)
```
`contract_check_items.evidence_id`의 FK가 **존재하지 않는 테이블** `trust_evidence_items`를 참조했습니다. 실제 근거 테이블은 `trust_evidence_nodes`(migration-024에서 생성, `lib/trust-engine.ts` 전반에서 사용). `trust_evidence_items`는 저장소 어디에서도 생성되지 않으며 이 FK 한 줄과 오래된 문서에만 등장하는 오타입니다.

## 변경
```diff
- evidence_id UUID REFERENCES trust_evidence_items(id),
+ evidence_id UUID REFERENCES trust_evidence_nodes(id),
```

## 안전성
- 028은 지금까지 어떤 환경에도 적용된 적이 없음(항상 실패) → 기존 마이그레이션 이력 훼손 없음
- 028~031 전부 추가형(`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN ... DEFAULT`)이라 재적용 안전
- `trust_evidence_nodes(id)`는 `UUID PRIMARY KEY`로 FK 대상 유효

## 병합 후 후속
`main` 병합 후 `DB Migration` 워크플로우를 `apply` 모드로 재실행하여 028~031 적용 → cron 재검증 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated contract report evidence references to use the correct evidence records, improving data consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->