### PR TITLE
fix(db): drop legacy disclosure-policy unique constraint by lookup in migration-031

### DIFF
--- a/db/migration-031-trust-disclosure-matrix.sql
+++ b/db/migration-031-trust-disclosure-matrix.sql
@@ -10,11 +10,39 @@ UPDATE trust_disclosure_policies
 ALTER TABLE trust_disclosure_policies
   DROP CONSTRAINT IF EXISTS ck_trust_disclosure_stage_purpose_level;
 ALTER TABLE trust_disclosure_policies
+  DROP CONSTRAINT IF EXISTS ck_trust_disclosure_verification_level;
+ALTER TABLE trust_disclosure_policies
   ADD CONSTRAINT ck_trust_disclosure_verification_level
     CHECK (verification_level BETWEEN 0 AND 2);
 
+-- Drop the legacy 5-column unique constraint regardless of its auto-generated
+-- name. PostgreSQL truncates auto names to 63 bytes, so the original became
+-- trust_disclosure_policies_version_subject_type_recipient_ro_key rather than
+-- the full ..._transaction_stage_purpose_key the earlier attempt tried to drop.
+DO $$
+DECLARE
+  legacy_conname text;
+BEGIN
+  SELECT c.conname INTO legacy_conname
+  FROM pg_constraint c
+  JOIN pg_class t ON t.oid = c.conrelid
+  JOIN pg_namespace n ON n.oid = t.relnamespace
+  WHERE t.relname = 'trust_disclosure_policies'
+    AND n.nspname = current_schema()
+    AND c.contype = 'u'
+    AND (
+      SELECT array_agg(a.attname ORDER BY a.attname)
+      FROM pg_attribute a
+      WHERE a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
+    ) = ARRAY['purpose', 'recipient_role', 'subject_type', 'transaction_stage', 'version']::name[];
+
+  IF legacy_conname IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE trust_disclosure_policies DROP CONSTRAINT %I', legacy_conname);
+  END IF;
+END $$;
+
 ALTER TABLE trust_disclosure_policies
-  DROP CONSTRAINT IF EXISTS trust_disclosure_policies_version_subject_type_recipient_role_transaction_stage_purpose_key;
+  DROP CONSTRAINT IF EXISTS uq_trust_disclosure_policies_matrix;
 ALTER TABLE trust_disclosure_policies
   ADD CONSTRAINT uq_trust_disclosure_policies_matrix
     UNIQUE (version, subject_type, recipient_role, transaction_stage, purpose, verification_level);
@@ -77,6 +105,8 @@ UPDATE trust_disclosure_packages
    SET verification_level = 0
  WHERE verification_level IS NULL;
 
+ALTER TABLE trust_disclosure_packages
+  DROP CONSTRAINT IF EXISTS ck_trust_disclosure_package_verification_level;
 ALTER TABLE trust_disclosure_packages
   ADD CONSTRAINT ck_trust_disclosure_package_verification_level
     CHECK (verification_level BETWEEN 0 AND 2);


### PR DESCRIPTION
## 문제
`DB Migration` apply에서 028·029·030은 성공 적용됐으나 **031이 실패**:
```
[apply] migration-031-trust-disclosure-matrix.sql
error: duplicate key value violates unique constraint
  "trust_disclosure_policies_version_subject_type_recipient_ro_key"
detail: Key (version, subject_type, recipient_role, transaction_stage, purpose)=
  (minimum-claims-1.0, tenant, landlord, pre_application, tenant_profile_view) already exists.
```

## 근본원인
031은 기존 5컬럼 UNIQUE 제약을 verification_level 포함 6컬럼 매트릭스 제약으로 교체하려 했습니다. 하지만 옛 제약을 **풀네임**(`..._recipient_role_transaction_stage_purpose_key`)으로 DROP하려 했는데, PostgreSQL이 자동생성 이름을 63바이트로 잘라 실제 이름은 `..._recipient_ro_key`였습니다. DROP이 no-op이 되어 옛 제약이 살아남았고, level=1/2 시드 INSERT가 충돌했습니다.

## 변경
- 옛 5컬럼 UNIQUE 제약을 **컬럼 구성으로 조회해 실제 이름으로 DROP**(이름 truncation에 무관)
- check/unique 제약에 `DROP CONSTRAINT IF EXISTS` guard 추가 → 재실행 안전(idempotent)

## 상태
- 각 마이그레이션은 `BEGIN…COMMIT` 트랜잭션 → 실패한 031은 완전 롤백, 028·029·030은 커밋·기록 완료
- 병합 후 `DB Migration` apply 재실행 시 031만 적용 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)