### PR TITLE
chore(cron): remove temporary trust-cron 500 diagnostics

### DIFF
--- a/app/api/cron/trust-maintenance/route.ts
+++ b/app/api/cron/trust-maintenance/route.ts
@@ -12,11 +12,7 @@ export async function GET(request: Request) {
     return jsonSuccess(request, await runTrustMaintenance(getRequestContext(request)))
   } catch (error) {
     console.error('Trust maintenance failed:', error)
-    // TEMP DIAGNOSTIC (cron-secret-gated; caller already authenticated above):
-    // surface the real pg error so we can pinpoint the runtime cause. Remove after fix.
-    const e = error as { message?: string; code?: string; detail?: string; table?: string; column?: string; routine?: string }
-    const detail = [e.message, e.code && `code=${e.code}`, e.detail && `detail=${e.detail}`, e.table && `table=${e.table}`, e.column && `column=${e.column}`, e.routine && `routine=${e.routine}`].filter(Boolean).join(' | ')
-    return jsonError(request, 500, `Trust maintenance failed: ${detail}`, 'TRUST_MAINTENANCE_FAILED')
+    return jsonError(request, 500, 'Trust maintenance failed', 'TRUST_MAINTENANCE_FAILED')
   }
 }
 

--- a/app/api/cron/trust-outbox/route.ts
+++ b/app/api/cron/trust-outbox/route.ts
@@ -1,5 +1,4 @@
 import { dispatchTrustOutbox } from '@/lib/trust-outbox'
-import { query } from '@/lib/db'
 import { jsonError, jsonSuccess } from '@/lib/api-response'
 
 export async function GET(request: Request) {
@@ -11,25 +10,6 @@ export async function GET(request: Request) {
     return jsonSuccess(request, await dispatchTrustOutbox(50))
   } catch (error) {
     console.error('Trust outbox dispatch failed:', error)
-    // TEMP DIAGNOSTIC (cron-secret-gated; caller already authenticated above):
-    // surface the real pg error + DB identity/search_path so we can pinpoint the
-    // runtime cause (suspected runtime DB != migrated DB). Remove after fix.
-    const e = error as { message?: string; code?: string; detail?: string; table?: string; column?: string; routine?: string }
-    let probe = ''
-    try {
-      const rows = await query<{ db: string; sp: string; ipjuhae: string | null; pub: string | null }>(
-        `SELECT current_database() AS db,
-                current_setting('search_path') AS sp,
-                to_regclass('ipjuhae.trust_outbox_events')::text AS ipjuhae,
-                to_regclass('public.trust_outbox_events')::text AS pub`
-      )
-      const r = rows[0]
-      probe = ` | db=${r?.db} | search_path=${r?.sp} | ipjuhae.trust_outbox_events=${r?.ipjuhae ?? 'MISSING'} | public.trust_outbox_events=${r?.pub ?? 'MISSING'}`
-    } catch (probeErr) {
-      probe = ` | probe_failed=${probeErr instanceof Error ? probeErr.message : String(probeErr)}`
-    }
-    const detail = [e.message, e.code && `code=${e.code}`, e.detail && `detail=${e.detail}`, e.table && `table=${e.table}`, e.column && `column=${e.column}`, e.routine && `routine=${e.routine}`].filter(Boolean).join(' | ')
-    return jsonError(request, 500, `Trust outbox dispatch failed: ${detail}${probe}`, 'TRUST_OUTBOX_FAILED')
+    return jsonError(request, 500, 'Trust outbox dispatch failed', 'TRUST_OUTBOX_FAILED')
   }
 }
-


### PR DESCRIPTION
The trust cron 500 root cause is fixed (Fly runtime DB was missing migrations 024+; applied via db-migrate-runtime). Reverts the temporary cron-secret-gated diagnostics in the trust-outbox/maintenance routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)