### PR TITLE
feat: apply 입주해 brand theme + unify product name

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/auth'
 import Link from 'next/link'
 
-export const metadata = { title: 'Admin | Rentme' }
+export const metadata = { title: 'Admin | 입주해' }
 
 const adminNav = [
   { href: '/admin', label: 'Dashboard' },

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,59 +1,67 @@
+/* 입주해 브랜드 폰트 — Pretendard */
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * 입주해 브랜드 시스템 v1.0 (1a · 온기)
+ * 핵심: 감빛 오렌지 #f0663f, 앰버 #e8a33d, 버터 #fff3dc, 크림 #fbf6ef, 잉크 #262220
+ * 값은 shadcn HSL 토큰으로 매핑됨.
+ */
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --background: 36 50% 97%; /* 크림 #fbf6ef */
+    --foreground: 20 12% 14%; /* 잉크 #262220 */
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 20 12% 14%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 168 76% 42%;
+    --popover-foreground: 20 12% 14%;
+    --primary: 14 85% 59%; /* 감빛 오렌지 #f0663f */
     --primary-foreground: 0 0% 100%;
-    --secondary: 170 30% 95%;
-    --secondary-foreground: 168 76% 25%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 38 92% 50%;
-    --accent-foreground: 38 92% 15%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --success: 142 76% 36%;
+    --secondary: 39 100% 93%; /* 버터 #fff3dc */
+    --secondary-foreground: 24 30% 22%;
+    --muted: 37 40% 92%; /* 라이트 크림 #f3ede3 */
+    --muted-foreground: 32 10% 49%; /* 토프 #8a7e70 */
+    --accent: 36 79% 57%; /* 앰버 #e8a33d */
+    --accent-foreground: 30 45% 16%;
+    --destructive: 355 64% 55%;
+    --destructive-foreground: 0 0% 100%;
+    --success: 152 32% 36%; /* 세이지 그린 #3f7a5e */
     --success-foreground: 0 0% 100%;
-    --warning: 38 92% 50%;
-    --warning-foreground: 38 92% 15%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 168 76% 42%;
-    --radius: 0.5rem;
+    --warning: 36 79% 57%; /* 앰버 */
+    --warning-foreground: 30 45% 16%;
+    --border: 36 30% 82%; /* 웜 보더 #e0d3bf */
+    --input: 36 30% 82%;
+    --ring: 14 85% 59%;
+    --radius: 0.875rem; /* 14px — 카드·버튼 기준 */
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 168 76% 50%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 170 30% 15%;
-    --secondary-foreground: 168 76% 80%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 38 92% 50%;
-    --accent-foreground: 38 92% 95%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --success: 142 76% 36%;
-    --success-foreground: 0 0% 100%;
-    --warning: 38 92% 50%;
-    --warning-foreground: 38 92% 15%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 168 76% 50%;
+    --background: 24 12% 10%;
+    --foreground: 36 40% 94%;
+    --card: 24 12% 13%;
+    --card-foreground: 36 40% 94%;
+    --popover: 24 12% 13%;
+    --popover-foreground: 36 40% 94%;
+    --primary: 14 88% 62%;
+    --primary-foreground: 20 20% 10%;
+    --secondary: 28 18% 20%;
+    --secondary-foreground: 39 60% 88%;
+    --muted: 26 12% 20%;
+    --muted-foreground: 34 15% 66%;
+    --accent: 36 80% 60%;
+    --accent-foreground: 30 40% 12%;
+    --destructive: 355 60% 55%;
+    --destructive-foreground: 0 0% 100%;
+    --success: 152 40% 50%;
+    --success-foreground: 20 20% 10%;
+    --warning: 36 80% 60%;
+    --warning-foreground: 30 40% 12%;
+    --border: 28 12% 22%;
+    --input: 28 12% 22%;
+    --ring: 14 88% 62%;
   }
 }
 

--- a/app/landlord/favorites/layout.tsx
+++ b/app/landlord/favorites/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '즐겨찾기 | 임주해',
-  description: '임주해(Rentme)에서 저장한 세입자 프로필을 확인하세요. 관심 있는 세입자들을 즐겨찾기에 추가하고 쉽게 관리할 수 있습니다.',
+  title: '즐겨찾기 | 입주해',
+  description: '입주해에서 저장한 세입자 프로필을 확인하세요. 관심 있는 세입자들을 즐겨찾기에 추가하고 쉽게 관리할 수 있습니다.',
   openGraph: {
-    title: '즐겨찾기 | 임주해',
-    description: '임주해(Rentme)에서 저장한 세입자 프로필을 확인하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 즐겨찾기' }],
+    title: '즐겨찾기 | 입주해',
+    description: '입주해에서 저장한 세입자 프로필을 확인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 즐겨찾기' }],
   },
   robots: {
     index: false,

--- a/app/landlord/layout.tsx
+++ b/app/landlord/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '집주인 대시보드',
-  description: '임주해(Rentme) 집주인 대시보드에서 매물을 관리하고 신뢰할 수 있는 세입자를 찾아보세요. 세입자 프로필 기반 부동산 매칭 플랫폼.',
+  description: '입주해 집주인 대시보드에서 매물을 관리하고 신뢰할 수 있는 세입자를 찾아보세요. 세입자 프로필 기반 부동산 매칭 플랫폼.',
   openGraph: {
-    title: '집주인 대시보드 | 임주해',
-    description: '임주해(Rentme) 집주인 대시보드에서 매물을 관리하고 신뢰할 수 있는 세입자를 찾아보세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 집주인 대시보드' }],
+    title: '집주인 대시보드 | 입주해',
+    description: '입주해 집주인 대시보드에서 매물을 관리하고 신뢰할 수 있는 세입자를 찾아보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 집주인 대시보드' }],
   },
   robots: {
     index: false,

--- a/app/landlord/messages/layout.tsx
+++ b/app/landlord/messages/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '메시지 | 임주해',
-  description: '임주해(Rentme) 집주인 메시지 센터에서 세입자와 나눈 대화를 확인하세요. 실시간 채팅으로 세입자와 안전하게 소통할 수 있습니다.',
+  title: '메시지 | 입주해',
+  description: '입주해 집주인 메시지 센터에서 세입자와 나눈 대화를 확인하세요. 실시간 채팅으로 세입자와 안전하게 소통할 수 있습니다.',
   openGraph: {
-    title: '메시지 | 임주해',
-    description: '임주해(Rentme) 집주인 메시지 센터에서 세입자와의 대화를 확인하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 집주인 메시지' }],
+    title: '메시지 | 입주해',
+    description: '입주해 집주인 메시지 센터에서 세입자와의 대화를 확인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 집주인 메시지' }],
   },
   robots: {
     index: false,

--- a/app/landlord/onboarding/layout.tsx
+++ b/app/landlord/onboarding/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '집주인 프로필 설정 | 임주해',
-  description: '임주해(Rentme)에서 집주인 프로필을 설정하세요. 이름, 연락처, 보유 매물 수와 지역을 입력하고 신뢰할 수 있는 세입자를 찾아보세요.',
+  title: '집주인 프로필 설정 | 입주해',
+  description: '입주해에서 집주인 프로필을 설정하세요. 이름, 연락처, 보유 매물 수와 지역을 입력하고 신뢰할 수 있는 세입자를 찾아보세요.',
   openGraph: {
-    title: '집주인 프로필 설정 | 임주해',
-    description: '임주해(Rentme)에서 집주인 프로필을 설정하고 신뢰할 수 있는 세입자를 찾아보세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 집주인 프로필 설정' }],
+    title: '집주인 프로필 설정 | 입주해',
+    description: '입주해에서 집주인 프로필을 설정하고 신뢰할 수 있는 세입자를 찾아보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 집주인 프로필 설정' }],
   },
   robots: {
     index: false,

--- a/app/landlord/profile/layout.tsx
+++ b/app/landlord/profile/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '집주인 프로필 수정 | 임주해',
-  description: '임주해(Rentme)에서 집주인 프로필을 수정하세요. 이름, 연락처, 보유 매물 수와 지역 정보를 업데이트할 수 있습니다.',
+  title: '집주인 프로필 수정 | 입주해',
+  description: '입주해에서 집주인 프로필을 수정하세요. 이름, 연락처, 보유 매물 수와 지역 정보를 업데이트할 수 있습니다.',
   openGraph: {
-    title: '집주인 프로필 수정 | 임주해',
-    description: '임주해(Rentme)에서 집주인 프로필 정보를 수정하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 집주인 프로필 수정' }],
+    title: '집주인 프로필 수정 | 입주해',
+    description: '입주해에서 집주인 프로필 정보를 수정하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 집주인 프로필 수정' }],
   },
   robots: {
     index: false,

--- a/app/landlord/properties/layout.tsx
+++ b/app/landlord/properties/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '내 매물 | 임주해',
-  description: '임주해(Rentme)에서 등록한 매물을 관리하세요. 매물 상태 변경, 사진 업로드, 세입자 매칭까지 한 곳에서 처리할 수 있습니다.',
+  title: '내 매물 | 입주해',
+  description: '입주해에서 등록한 매물을 관리하세요. 매물 상태 변경, 사진 업로드, 세입자 매칭까지 한 곳에서 처리할 수 있습니다.',
   openGraph: {
-    title: '내 매물 | 임주해',
-    description: '임주해(Rentme)에서 등록한 매물을 관리하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 매물 관리' }],
+    title: '내 매물 | 입주해',
+    description: '입주해에서 등록한 매물을 관리하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 매물 관리' }],
   },
   robots: {
     index: false,

--- a/app/landlord/properties/new/layout.tsx
+++ b/app/landlord/properties/new/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '매물 등록 | 임주해',
-  description: '임주해(Rentme)에서 새 매물을 등록하세요. 주소, 가격, 방 정보, 옵션 등을 입력하고 신뢰할 수 있는 세입자를 만나보세요.',
+  title: '매물 등록 | 입주해',
+  description: '입주해에서 새 매물을 등록하세요. 주소, 가격, 방 정보, 옵션 등을 입력하고 신뢰할 수 있는 세입자를 만나보세요.',
   openGraph: {
-    title: '매물 등록 | 임주해',
-    description: '임주해(Rentme)에서 새 매물을 등록하고 신뢰할 수 있는 세입자를 만나보세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 매물 등록' }],
+    title: '매물 등록 | 입주해',
+    description: '입주해에서 새 매물을 등록하고 신뢰할 수 있는 세입자를 만나보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 매물 등록' }],
   },
   robots: {
     index: false,

--- a/app/landlord/stats/layout.tsx
+++ b/app/landlord/stats/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '통계 및 분석 | 임주해',
-  description: '임주해(Rentme) 집주인 통계 대시보드에서 매물 현황, 조회수, 즐겨찾기, 메시지 등 활동 데이터를 확인하세요.',
+  title: '통계 및 분석 | 입주해',
+  description: '입주해 집주인 통계 대시보드에서 매물 현황, 조회수, 즐겨찾기, 메시지 등 활동 데이터를 확인하세요.',
   openGraph: {
-    title: '통계 및 분석 | 임주해',
-    description: '임주해(Rentme) 집주인 통계 대시보드에서 매물 현황과 활동 데이터를 확인하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 통계 및 분석' }],
+    title: '통계 및 분석 | 입주해',
+    description: '입주해 집주인 통계 대시보드에서 매물 현황과 활동 데이터를 확인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 통계 및 분석' }],
   },
   robots: {
     index: false,

--- a/app/landlord/tenants/layout.tsx
+++ b/app/landlord/tenants/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '세입자 찾기 | 임주해',
-  description: '임주해(Rentme)에서 인증된 세입자 프로필을 검색하세요. 연령대, 가구 유형, 신뢰점수 등 다양한 조건으로 맞는 세입자를 찾아볼 수 있습니다.',
+  title: '세입자 찾기 | 입주해',
+  description: '입주해에서 인증된 세입자 프로필을 검색하세요. 연령대, 가구 유형, 신뢰점수 등 다양한 조건으로 맞는 세입자를 찾아볼 수 있습니다.',
   openGraph: {
-    title: '세입자 찾기 | 임주해',
-    description: '임주해(Rentme)에서 인증된 세입자 프로필을 검색하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 세입자 찾기' }],
+    title: '세입자 찾기 | 입주해',
+    description: '입주해에서 인증된 세입자 프로필을 검색하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 세입자 찾기' }],
   },
   robots: {
     index: false,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,30 +7,30 @@ const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.ipjuhae.com'
 export const metadata: Metadata = {
   metadataBase: new URL(APP_URL),
   title: {
-    default: '임주해 | 세입자 프로필 기반 부동산 매칭',
-    template: '%s | 임주해',
+    default: '입주해 | 세입자 프로필 기반 부동산 매칭',
+    template: '%s | 입주해',
   },
   description: '신뢰할 수 있는 세입자 프로필로 집주인과 세입자를 매칭하는 서비스',
-  keywords: ['임주해', '세입자 프로필', '임대차 매칭', '전세 구하기', '월세 매칭', '부동산 매칭', '역방향 매칭', '집주인 선택', '임대인 매칭', '세입자 신뢰점수'],
+  keywords: ['입주해', '세입자 프로필', '임대차 매칭', '전세 구하기', '월세 매칭', '부동산 매칭', '역방향 매칭', '집주인 선택', '임대인 매칭', '세입자 신뢰점수'],
   openGraph: {
     type: 'website',
     locale: 'ko_KR',
     url: APP_URL,
-    siteName: '임주해',
-    title: '임주해 | 세입자 프로필 기반 부동산 매칭',
+    siteName: '입주해',
+    title: '입주해 | 세입자 프로필 기반 부동산 매칭',
     description: '신뢰할 수 있는 세입자 프로필로 집주인과 세입자를 매칭하는 서비스',
     images: [
       {
         url: '/opengraph-image',
         width: 1200,
         height: 630,
-        alt: '임주해 - 세입자 프로필 기반 부동산 매칭 플랫폼',
+        alt: '입주해 - 세입자 프로필 기반 부동산 매칭 플랫폼',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: '임주해 | 세입자 프로필 기반 부동산 매칭',
+    title: '입주해 | 세입자 프로필 기반 부동산 매칭',
     description: '신뢰할 수 있는 세입자 프로필로 집주인과 세입자를 매칭하는 서비스',
     images: ['/opengraph-image'],
   },
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
 const organizationJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'Organization',
-  name: '임주해',
+  name: '입주해',
   url: APP_URL,
   logo: `${APP_URL}/icon.png`,
   description: '신뢰할 수 있는 세입자 프로필로 집주인과 세입자를 매칭하는 서비스',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from 'next'
-import { Noto_Sans_KR } from 'next/font/google'
 import { Providers } from '@/components/providers'
 import './globals.css'
-
-const notoSansKR = Noto_Sans_KR({ subsets: ['latin'], weight: ['400', '500', '700'], display: 'swap' })
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.ipjuhae.com'
 
@@ -66,7 +63,7 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
         />
       </head>
-      <body className={notoSansKR.className}>
+      <body className="font-sans antialiased">
         <Providers>
           <main className="min-h-screen">
             {children}

--- a/app/listings/[id]/page.tsx
+++ b/app/listings/[id]/page.tsx
@@ -58,13 +58,13 @@ async function getListing(id: string) {
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const listing = await getListing(id)
-  if (!listing) return { title: 'Listing not found | Rentme' }
+  if (!listing) return { title: 'Listing not found | 입주해' }
   const desc = listing.description ?? `${listing.address} detail`
   return {
-    title: `${listing.address} | Rentme`,
+    title: `${listing.address} | 입주해`,
     description: desc,
     openGraph: {
-      title: `${listing.address} | Rentme`,
+      title: `${listing.address} | 입주해`,
       description: desc,
       images: [{ url: '/og-image.png', width: 1200, height: 630, alt: `${listing.address} listing` }],
     },

--- a/app/listings/page.tsx
+++ b/app/listings/page.tsx
@@ -18,12 +18,12 @@ async function getListings() {
 }
 
 export const metadata = {
-  title: 'Listing search | Rentme',
+  title: 'Listing search | 입주해',
   description: 'Search real, live listings by region and budget.',
   openGraph: {
-    title: 'Listing search | Rentme',
+    title: 'Listing search | 입주해',
     description: 'Search real, live listings by region and budget.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: 'Rentme listing list' }],
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 listing list' }],
   },
 }
 
@@ -35,7 +35,7 @@ export default async function ListingsPage() {
       <div className="space-y-8">
         <div className="rounded-lg bg-background p-6 shadow-soft">
           <div className="max-w-3xl space-y-3">
-            <p className="text-sm font-semibold text-primary">Rentme Search</p>
+            <p className="text-sm font-semibold text-primary">입주해 Search</p>
             <h1 className="text-3xl font-bold tracking-normal sm:text-4xl">Listing Search</h1>
             <p className="text-muted-foreground">
               Browse real listings and compare by region, budget, and conditions.

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '로그인',
-  description: '임주해(Rentme)에 로그인하세요. 세입자 프로필 기반 부동산 매칭 플랫폼에서 집주인과 세입자를 연결합니다.',
+  description: '입주해에 로그인하세요. 세입자 프로필 기반 부동산 매칭 플랫폼에서 집주인과 세입자를 연결합니다.',
   openGraph: {
-    title: '로그인 | 임주해',
-    description: '임주해(Rentme)에 로그인하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 로그인' }],
+    title: '로그인 | 입주해',
+    description: '입주해에 로그인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 로그인' }],
   },
   robots: {
     index: false,

--- a/app/messages/[id]/layout.tsx
+++ b/app/messages/[id]/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '대화 | 임주해',
-  description: '임주해(Rentme) 메시지 센터에서 집주인과 대화를 나누세요. 실시간 채팅으로 안전하게 소통할 수 있습니다.',
+  title: '대화 | 입주해',
+  description: '입주해 메시지 센터에서 집주인과 대화를 나누세요. 실시간 채팅으로 안전하게 소통할 수 있습니다.',
   openGraph: {
-    title: '대화 | 임주해',
-    description: '임주해(Rentme) 메시지 센터에서 집주인과 대화를 나누세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 메시지' }],
+    title: '대화 | 입주해',
+    description: '입주해 메시지 센터에서 집주인과 대화를 나누세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 메시지' }],
   },
   robots: {
     index: false,

--- a/app/messages/layout.tsx
+++ b/app/messages/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '메시지',
-  description: '임주해(Rentme) 메시지 센터에서 집주인과 세입자 간의 대화를 확인하세요.',
+  description: '입주해 메시지 센터에서 집주인과 세입자 간의 대화를 확인하세요.',
   openGraph: {
-    title: '메시지 | 임주해',
-    description: '임주해(Rentme) 메시지 센터에서 집주인과 세입자 간의 대화를 확인하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 메시지' }],
+    title: '메시지 | 입주해',
+    description: '입주해 메시지 센터에서 집주인과 세입자 간의 대화를 확인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 메시지' }],
   },
   robots: {
     index: false,

--- a/app/onboarding/basic/layout.tsx
+++ b/app/onboarding/basic/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '기본 정보 입력 | 임주해',
-  description: '임주해(Rentme) 세입자 프로필 설정 단계 1: 이름, 연령대, 가구 유형, 반려동물, 흡연 여부 등 기본 정보를 입력해주세요.',
+  title: '기본 정보 입력 | 입주해',
+  description: '입주해 세입자 프로필 설정 단계 1: 이름, 연령대, 가구 유형, 반려동물, 흡연 여부 등 기본 정보를 입력해주세요.',
   openGraph: {
-    title: '기본 정보 입력 | 임주해',
-    description: '임주해(Rentme) 세입자 프로필 설정 단계 1: 기본 정보를 입력해주세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 기본 정보 입력' }],
+    title: '기본 정보 입력 | 입주해',
+    description: '입주해 세입자 프로필 설정 단계 1: 기본 정보를 입력해주세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 기본 정보 입력' }],
   },
   robots: {
     index: false,

--- a/app/onboarding/complete/layout.tsx
+++ b/app/onboarding/complete/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '자기소개서 작성 | 임주해',
-  description: '임주해(Rentme) 세입자 프로필 설정 단계 3: 집주인에게 보낼 자기소개서를 작성하고 프로필을 완성하세요. AI가 작성을 도와드립니다.',
+  title: '자기소개서 작성 | 입주해',
+  description: '입주해 세입자 프로필 설정 단계 3: 집주인에게 보낼 자기소개서를 작성하고 프로필을 완성하세요. AI가 작성을 도와드립니다.',
   openGraph: {
-    title: '자기소개서 작성 | 임주해',
-    description: '임주해(Rentme) 세입자 프로필 설정 단계 3: 자기소개서를 작성하고 프로필을 완성하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 자기소개서 작성' }],
+    title: '자기소개서 작성 | 입주해',
+    description: '입주해 세입자 프로필 설정 단계 3: 자기소개서를 작성하고 프로필을 완성하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 자기소개서 작성' }],
   },
   robots: {
     index: false,

--- a/app/onboarding/layout.tsx
+++ b/app/onboarding/layout.tsx
@@ -4,11 +4,11 @@ import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: '프로필 설정',
-  description: '임주해(Rentme)에서 세입자 프로필을 만들어보세요. 기본 정보와 생활 패턴을 입력하면 신뢰할 수 있는 세입자임을 집주인에게 증명할 수 있습니다.',
+  description: '입주해에서 세입자 프로필을 만들어보세요. 기본 정보와 생활 패턴을 입력하면 신뢰할 수 있는 세입자임을 집주인에게 증명할 수 있습니다.',
   openGraph: {
-    title: '프로필 설정 | 임주해',
-    description: '임주해(Rentme)에서 세입자 프로필을 만들어보세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 프로필 설정' }],
+    title: '프로필 설정 | 입주해',
+    description: '입주해에서 세입자 프로필을 만들어보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 프로필 설정' }],
   },
   robots: {
     index: false,

--- a/app/onboarding/lifestyle/layout.tsx
+++ b/app/onboarding/lifestyle/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '생활 패턴 입력 | 임주해',
-  description: '임주해(Rentme) 세입자 프로필 설정 단계 2: 귀가 시간, 거주 기간, 소음 수준 등 생활 패턴 정보를 입력해주세요. 집주인이 맞는 세입자를 찾는 데 도움이 됩니다.',
+  title: '생활 패턴 입력 | 입주해',
+  description: '입주해 세입자 프로필 설정 단계 2: 귀가 시간, 거주 기간, 소음 수준 등 생활 패턴 정보를 입력해주세요. 집주인이 맞는 세입자를 찾는 데 도움이 됩니다.',
   openGraph: {
-    title: '생활 패턴 입력 | 임주해',
-    description: '임주해(Rentme) 세입자 프로필 설정 단계 2: 생활 패턴 정보를 입력해주세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 생활 패턴 입력' }],
+    title: '생활 패턴 입력 | 입주해',
+    description: '입주해 세입자 프로필 설정 단계 2: 생활 패턴 정보를 입력해주세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 생활 패턴 입력' }],
   },
   robots: {
     index: false,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,12 +8,12 @@ import { Button } from '@/components/ui/button'
 import type { Listing } from '@/lib/schemas/listing'
 
 export const metadata: Metadata = {
-  title: 'Rentme - 안전한 임대의 시작',
-  description: 'Rentme는 실제 등록된 매물 데이터로 임대 과정을 빠르게 탐색하고 매칭할 수 있는 플랫폼입니다.',
+  title: '입주해 - 안전한 임대의 시작',
+  description: '입주해는 실제 등록된 매물 데이터로 임대 과정을 빠르게 탐색하고 매칭할 수 있는 플랫폼입니다.',
   openGraph: {
-    title: 'Rentme - 안전한 임대의 시작',
-    description: 'Rentme는 실제 등록된 매물 데이터로 임대 과정을 빠르게 탐색하고 매칭할 수 있는 플랫폼입니다.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: 'Rentme 플랫폼 안내' }],
+    title: '입주해 - 안전한 임대의 시작',
+    description: '입주해는 실제 등록된 매물 데이터로 임대 과정을 빠르게 탐색하고 매칭할 수 있는 플랫폼입니다.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 플랫폼 안내' }],
   },
 }
 
@@ -52,7 +52,7 @@ export default async function HomePage() {
                 신뢰받는 매물 찾기
               </h1>
               <p className="max-w-xl text-lg leading-8 text-muted-foreground">
-                임차인과 임대인 모두를 위한 매칭 플랫폼, Rentme로 더 빠르게 안전한 계약을 시작하세요.
+                임차인과 임대인 모두를 위한 매칭 플랫폼, 입주해로 더 빠르게 안전한 계약을 시작하세요.
               </p>
             </div>
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -3,11 +3,11 @@ import { Header } from '@/components/layout/header'
 
 export const metadata: Metadata = {
   title: '개인정보처리방침',
-  description: '임주해(Rentme)의 개인정보처리방침을 확인하세요. 세입자 프로필 기반 부동산 매칭 플랫폼 임주해가 수집·이용하는 개인정보와 보호 정책을 안내합니다.',
+  description: '입주해의 개인정보처리방침을 확인하세요. 세입자 프로필 기반 부동산 매칭 플랫폼 입주해가 수집·이용하는 개인정보와 보호 정책을 안내합니다.',
   openGraph: {
-    title: '개인정보처리방침 | 임주해',
-    description: '임주해(Rentme)의 개인정보처리방침을 확인하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 개인정보처리방침' }],
+    title: '개인정보처리방침 | 입주해',
+    description: '입주해의 개인정보처리방침을 확인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 개인정보처리방침' }],
   },
   robots: {
     index: false,

--- a/app/profile/[id]/layout.tsx
+++ b/app/profile/[id]/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '세입자 프로필',
-  description: '임주해(Rentme)에서 세입자 프로필을 확인하세요. 신뢰점수와 인증 정보를 통해 믿을 수 있는 세입자를 만나보세요.',
+  description: '입주해에서 세입자 프로필을 확인하세요. 신뢰점수와 인증 정보를 통해 믿을 수 있는 세입자를 만나보세요.',
   openGraph: {
-    title: '세입자 프로필 | 임주해',
-    description: '임주해(Rentme)에서 세입자 프로필을 확인하세요. 신뢰점수와 인증 정보를 통해 믿을 수 있는 세입자를 만나보세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 세입자 프로필' }],
+    title: '세입자 프로필 | 입주해',
+    description: '입주해에서 세입자 프로필을 확인하세요. 신뢰점수와 인증 정보를 통해 믿을 수 있는 세입자를 만나보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 세입자 프로필' }],
   },
 }
 

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '내 프로필',
-  description: '임주해(Rentme)에서 내 세입자 프로필을 확인하고 관리하세요. 신뢰점수, 인증 정보, 레퍼런스를 한눈에 볼 수 있습니다.',
+  description: '입주해에서 내 세입자 프로필을 확인하고 관리하세요. 신뢰점수, 인증 정보, 레퍼런스를 한눈에 볼 수 있습니다.',
   openGraph: {
-    title: '내 프로필 | 임주해',
-    description: '임주해(Rentme)에서 내 세입자 프로필을 확인하고 관리하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 세입자 프로필' }],
+    title: '내 프로필 | 입주해',
+    description: '입주해에서 내 세입자 프로필을 확인하고 관리하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 세입자 프로필' }],
   },
   robots: {
     index: false,

--- a/app/profile/reference/layout.tsx
+++ b/app/profile/reference/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '레퍼런스 관리 | 임주해',
-  description: '임주해(Rentme)에서 이전 집주인으로부터 레퍼런스를 받아 신뢰점수를 높여보세요. 레퍼런스는 세입자의 신뢰도를 높이는 핵심 요소입니다.',
+  title: '레퍼런스 관리 | 입주해',
+  description: '입주해에서 이전 집주인으로부터 레퍼런스를 받아 신뢰점수를 높여보세요. 레퍼런스는 세입자의 신뢰도를 높이는 핵심 요소입니다.',
   openGraph: {
-    title: '레퍼런스 관리 | 임주해',
-    description: '임주해(Rentme)에서 이전 집주인으로부터 레퍼런스를 받아 신뢰점수를 높여보세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 레퍼런스 관리' }],
+    title: '레퍼런스 관리 | 입주해',
+    description: '입주해에서 이전 집주인으로부터 레퍼런스를 받아 신뢰점수를 높여보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 레퍼런스 관리' }],
   },
   robots: {
     index: false,

--- a/app/profile/verification/layout.tsx
+++ b/app/profile/verification/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '인증 관리 | 임주해',
-  description: '임주해(Rentme)에서 재직, 소득, 신용 인증을 완료하고 신뢰점수를 높여보세요. 인증된 세입자는 집주인에게 더 높은 신뢰를 받을 수 있습니다.',
+  title: '인증 관리 | 입주해',
+  description: '입주해에서 재직, 소득, 신용 인증을 완료하고 신뢰점수를 높여보세요. 인증된 세입자는 집주인에게 더 높은 신뢰를 받을 수 있습니다.',
   openGraph: {
-    title: '인증 관리 | 임주해',
-    description: '임주해(Rentme)에서 재직, 소득, 신용 인증을 완료하고 신뢰점수를 높여보세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 인증 관리' }],
+    title: '인증 관리 | 입주해',
+    description: '입주해에서 재직, 소득, 신용 인증을 완료하고 신뢰점수를 높여보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 인증 관리' }],
   },
   robots: {
     index: false,

--- a/app/reference/survey/layout.tsx
+++ b/app/reference/survey/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '집주인 레퍼런스 설문',
-  description: '임주해(Rentme) 집주인 레퍼런스 설문에 참여해주세요. 세입자의 신뢰점수 향상에 도움이 됩니다.',
+  description: '입주해 집주인 레퍼런스 설문에 참여해주세요. 세입자의 신뢰점수 향상에 도움이 됩니다.',
   openGraph: {
-    title: '집주인 레퍼런스 설문 | 임주해',
-    description: '임주해(Rentme) 집주인 레퍼런스 설문에 참여해주세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 레퍼런스 설문' }],
+    title: '집주인 레퍼런스 설문 | 입주해',
+    description: '입주해 집주인 레퍼런스 설문에 참여해주세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 레퍼런스 설문' }],
   },
   robots: {
     index: false,

--- a/app/signup/layout.tsx
+++ b/app/signup/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '회원가입',
-  description: '임주해(Rentme)에 가입하고 세입자 프로필을 만들어보세요. 세입자 프로필 기반 부동산 매칭 플랫폼에서 신뢰할 수 있는 세입자임을 증명하세요.',
+  description: '입주해에 가입하고 세입자 프로필을 만들어보세요. 세입자 프로필 기반 부동산 매칭 플랫폼에서 신뢰할 수 있는 세입자임을 증명하세요.',
   openGraph: {
-    title: '회원가입 | 임주해',
-    description: '임주해(Rentme)에 가입하고 세입자 프로필을 만들어보세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 회원가입' }],
+    title: '회원가입 | 입주해',
+    description: '입주해에 가입하고 세입자 프로필을 만들어보세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 회원가입' }],
   },
   robots: {
     index: false,

--- a/app/signup/social/layout.tsx
+++ b/app/signup/social/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '소셜 회원가입 | 임주해',
-  description: '소셜 계정으로 임주해(Rentme)에 가입하세요. 회원 유형을 선택하고 이용약관에 동의하면 바로 서비스를 이용할 수 있습니다.',
+  title: '소셜 회원가입 | 입주해',
+  description: '소셜 계정으로 입주해에 가입하세요. 회원 유형을 선택하고 이용약관에 동의하면 바로 서비스를 이용할 수 있습니다.',
   openGraph: {
-    title: '소셜 회원가입 | 임주해',
-    description: '소셜 계정으로 임주해(Rentme)에 가입하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 소셜 회원가입' }],
+    title: '소셜 회원가입 | 입주해',
+    description: '소셜 계정으로 입주해에 가입하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 소셜 회원가입' }],
   },
   robots: {
     index: false,

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -3,11 +3,11 @@ import { Header } from '@/components/layout/header'
 
 export const metadata: Metadata = {
   title: '이용약관',
-  description: '임주해(Rentme) 서비스 이용약관을 확인하세요. 세입자 프로필 기반 부동산 매칭 플랫폼 임주해의 서비스 이용 조건 및 정책을 안내합니다.',
+  description: '입주해 서비스 이용약관을 확인하세요. 세입자 프로필 기반 부동산 매칭 플랫폼 입주해의 서비스 이용 조건 및 정책을 안내합니다.',
   openGraph: {
-    title: '이용약관 | 임주해',
-    description: '임주해(Rentme) 서비스 이용약관을 확인하세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 이용약관' }],
+    title: '이용약관 | 입주해',
+    description: '입주해 서비스 이용약관을 확인하세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 이용약관' }],
   },
   robots: {
     index: false,

--- a/app/verify-phone/layout.tsx
+++ b/app/verify-phone/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '휴대폰 인증',
-  description: '임주해(Rentme) 본인 확인을 위해 휴대폰 번호를 인증해주세요. 인증 완료 시 신뢰점수가 향상됩니다.',
+  description: '입주해 본인 확인을 위해 휴대폰 번호를 인증해주세요. 인증 완료 시 신뢰점수가 향상됩니다.',
   openGraph: {
-    title: '휴대폰 인증 | 임주해',
-    description: '임주해(Rentme) 본인 확인을 위해 휴대폰 번호를 인증해주세요.',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '임주해 휴대폰 인증' }],
+    title: '휴대폰 인증 | 입주해',
+    description: '입주해 본인 확인을 위해 휴대폰 번호를 인증해주세요.',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: '입주해 휴대폰 인증' }],
   },
   robots: {
     index: false,

--- a/components/landing/cta-section.tsx
+++ b/components/landing/cta-section.tsx
@@ -12,7 +12,7 @@ export function CtaSection() {
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          className="max-w-3xl mx-auto rounded-2xl bg-gradient-to-r from-primary to-emerald-500 p-10 md:p-14 text-center text-white"
+          className="max-w-3xl mx-auto rounded-2xl bg-gradient-to-r from-primary to-accent p-10 md:p-14 text-center text-white"
         >
           <h2 className="text-3xl md:text-4xl font-bold">지금 바로 시작하세요</h2>
           <p className="mt-4 text-lg text-white/80">

--- a/components/landing/waitlist-section.tsx
+++ b/components/landing/waitlist-section.tsx
@@ -75,7 +75,7 @@ export function WaitlistSection() {
             서비스 출시 알림 신청
           </h2>
           <p className="mt-4 text-muted-foreground text-lg leading-relaxed">
-            임주해 서비스 출시 시 가장 먼저 알림을 받으세요.
+            입주해 서비스 출시 시 가장 먼저 알림을 받으세요.
             <br />
             <span className="text-primary font-medium">사전 신청자에게 3개월 프리미엄 무료 혜택</span>을 드립니다.
           </p>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -56,7 +56,7 @@ export function Header({ user }: HeaderProps) {
           <div className="flex items-center gap-6">
             <Link href="/" className="flex items-center gap-2">
               <Home className="h-6 w-6 text-primary" />
-              <span className="text-xl font-bold">RentMe</span>
+              <span className="text-xl font-bold">입주해</span>
               {user?.userType === 'landlord' && (
                 <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full">Landlord</span>
               )}

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -20,7 +20,7 @@ export function MobileNav({ open, onClose, user, navLinks, onLogout }: MobileNav
       <div className="flex flex-col gap-6">
         <Link href="/" className="flex items-center gap-2" onClick={onClose}>
           <Home className="h-6 w-6 text-primary" />
-          <span className="text-xl font-bold">RentMe</span>
+          <span className="text-xl font-bold">입주해</span>
         </Link>
 
         {user && (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,7 +68,7 @@ const config: Config = {
         'scale-in': 'scale-in 0.3s ease-out forwards',
       },
       fontFamily: {
-        sans: ['Inter', 'Noto Sans KR', 'system-ui', 'sans-serif'],
+        sans: ['Pretendard Variable', 'Pretendard', 'Noto Sans KR', 'system-ui', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
Applies the Claude-designed 입주해 brand system (direction 1a · 온기) as the app-wide theme, plus product-name unification.

**Theme (globals.css / tailwind.config.ts):** persimmon #f0663f primary, amber #e8a33d accent, butter #fff3dc secondary, cream #fbf6ef background, ink #262220 text, sage #3f7a5e success — mapped to shadcn HSL tokens (light + warm dark). Pretendard font. 14px radius. Landing CTA gradient fixed.

**Name:** 임주해 / RentMe / Rentme → 입주해 across user-facing metadata, JSON-LD, and header/mobile-nav logo. Domain, package name, and local demo QA page unchanged.

Trust/success greens are intentionally kept (they match the design's own sage success color). Verified locally (dev preview) and `next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)