### PR TITLE
feat(brand): 입주해 logo symbol, favicon & app icon

### DIFF
--- a/app/apple-icon.svg
+++ b/app/apple-icon.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 180 180" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="180" rx="40" fill="#f0663f"/>
+  <path d="M45 96 L90 55 L135 96" fill="none" stroke="#fff3dc" stroke-width="16" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="72" cy="113" r="13.5" fill="#fff3dc"/>
+  <circle cx="108" cy="113" r="13.5" fill="#ffd9a0"/>
+</svg>

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <rect width="48" height="48" rx="11" fill="#fff3dc"/>
+  <path d="M9 24 L24 11 L39 24" fill="none" stroke="#f0663f" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="18.5" cy="30.5" r="4" fill="#f0663f"/>
+  <circle cx="29.5" cy="30.5" r="4" fill="#e8a33d"/>
+</svg>

--- a/components/brand/logo-symbol.tsx
+++ b/components/brand/logo-symbol.tsx
@@ -1,0 +1,44 @@
+/**
+ * 입주해 브랜드 심볼 — "지붕 아래 두 사람"
+ * 좌: 세입자(감빛 #f0663f) · 우: 집주인(앰버 #e8a33d)
+ * 지붕은 두 사람을 함께 감싸는 신뢰의 지붕선.
+ */
+export function LogoSymbol({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      role="img"
+      aria-label="입주해"
+    >
+      {/* 지붕 */}
+      <path
+        d="M7 22 L24 8 L41 22"
+        stroke="#f0663f"
+        strokeWidth="4.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* 세입자 (좌 · 감빛) */}
+      <circle cx="18" cy="26.5" r="3.5" fill="#f0663f" />
+      <path
+        d="M13 40 C13 36.3 15.2 33.4 18 33.4 C20.8 33.4 23 36.3 23 40"
+        stroke="#f0663f"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* 집주인 (우 · 앰버) */}
+      <circle cx="30" cy="26.5" r="3.5" fill="#e8a33d" />
+      <path
+        d="M25 40 C25 36.3 27.2 33.4 30 33.4 C32.8 33.4 35 36.3 35 40"
+        stroke="#e8a33d"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { Home, Menu, LogOut, User, Shield, FileText, Eye, MessageSquare } from 'lucide-react'
+import { Menu, LogOut, User, Shield, FileText, Eye, MessageSquare } from 'lucide-react'
+import { LogoSymbol } from '@/components/brand/logo-symbol'
 import { Button } from '@/components/ui/button'
 import { Avatar } from '@/components/ui/avatar'
 import { DropdownMenu, DropdownMenuItem } from '@/components/ui/dropdown-menu'
@@ -55,7 +56,7 @@ export function Header({ user }: HeaderProps) {
         <div className="container mx-auto px-4 h-16 flex items-center justify-between">
           <div className="flex items-center gap-6">
             <Link href="/" className="flex items-center gap-2">
-              <Home className="h-6 w-6 text-primary" />
+              <LogoSymbol className="h-7 w-7" />
               <span className="text-xl font-bold">입주해</span>
               {user?.userType === 'landlord' && (
                 <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full">Landlord</span>

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import Link from 'next/link'
-import { Home, LogOut } from 'lucide-react'
+import { LogOut } from 'lucide-react'
+import { LogoSymbol } from '@/components/brand/logo-symbol'
 import { Avatar } from '@/components/ui/avatar'
 import { Sheet } from '@/components/ui/sheet'
 import { ThemeToggle } from './theme-toggle'
@@ -19,7 +20,7 @@ export function MobileNav({ open, onClose, user, navLinks, onLogout }: MobileNav
     <Sheet open={open} onClose={onClose}>
       <div className="flex flex-col gap-6">
         <Link href="/" className="flex items-center gap-2" onClick={onClose}>
-          <Home className="h-6 w-6 text-primary" />
+          <LogoSymbol className="h-7 w-7" />
           <span className="text-xl font-bold">입주해</span>
         </Link>
 


### PR DESCRIPTION
Replaces the generic Home glyph with the brand symbol (roof over two people — tenant #f0663f / landlord #e8a33d) in header + mobile nav, and adds app/icon.svg (favicon) and app/apple-icon.svg (app icon), auto-linked by Next.js. Verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)