### PR TITLE
fix(security): stop unauthenticated tenant-PII leak in /api/profile/[id]

### DIFF
--- a/app/api/profile/[id]/route.ts
+++ b/app/api/profile/[id]/route.ts
@@ -24,6 +24,17 @@ export async function GET(
     const { id } = await params
     const actor = await getCurrentUser().catch(() => null)
 
+    // A tenant profile carries PII (name, references, verification). Only the
+    // owner or a landlord may view it, and a landlord only ever sees what the
+    // tenant's active consent permits. Everyone else is denied — never fall
+    // through to the raw record.
+    if (!actor) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다', request_id: requestId, trace_id: traceId },
+        { status: 401 }
+      )
+    }
+
     const profile = await queryOne<Profile>(
       'SELECT * FROM profiles WHERE id = $1 AND is_complete = true',
       [id]
@@ -36,14 +47,27 @@ export async function GET(
       )
     }
 
-    const consent = actor?.user_type === 'landlord'
-      ? await getTenantProfileConsent(profile.user_id)
-      : null
-    const visibility = actor?.user_type === 'landlord' && consent
-      ? getTenantProfileVisibility(consent)
-      : null
+    const isOwner = actor.id === profile.user_id
+    const isLandlord = actor.user_type === 'landlord'
 
-    const verification = visibility?.verification
+    if (!isOwner && !isLandlord) {
+      return NextResponse.json(
+        { error: '이 프로필에 접근할 권한이 없습니다', request_id: requestId, trace_id: traceId },
+        { status: 403 }
+      )
+    }
+
+    // Owner sees everything. A landlord sees only consent-permitted fields;
+    // getTenantProfileVisibility(null) returns all-false (fully masked) when
+    // there is no active consent.
+    const consent = isLandlord && !isOwner ? await getTenantProfileConsent(profile.user_id) : null
+    const visibility = isOwner ? null : getTenantProfileVisibility(consent)
+
+    const canSeeVerification = isOwner || !!visibility?.verification
+    const canSeeReferences = isOwner || !!visibility?.references
+    const canSeeTrustScore = isOwner || !!visibility?.trust_score
+
+    const verification = canSeeVerification
       ? await queryOne<Verification>('SELECT * FROM verifications WHERE user_id = $1', [profile.user_id])
       : null
 
@@ -54,8 +78,8 @@ export async function GET(
       [profile.user_id]
     )
 
-    const visibleReferenceResponses = !visibility || visibility.references ? referenceResponses : []
-    const scoreBreakdown = visibility?.trust_score
+    const visibleReferenceResponses = canSeeReferences ? referenceResponses : []
+    const scoreBreakdown = canSeeTrustScore
       ? calculateTrustScore({
           profile,
           verification,


### PR DESCRIPTION
Consent masking only ran for landlord callers, so anonymous/tenant/broker requests received the raw tenant profile + all landlord references (consent-system bypass, PIPA exposure). Now: 401 if unauthenticated, 403 unless owner or landlord, non-owner views always masked per active consent. Owner keeps full access. 🤖 Generated with [Claude Code](https://claude.com/claude-code)