### PR TITLE
fix(payments): subscription expiry, plan-limit enforcement, prod demo gate

### DIFF
--- a/app/api/landlord/properties/route.ts
+++ b/app/api/landlord/properties/route.ts
@@ -4,6 +4,7 @@ import { verifyToken } from '@/lib/auth'
 import { query } from '@/lib/db'
 import { z } from 'zod'
 import { sanitizeUserInput } from '@/lib/sanitize'
+import { PLAN_LIMITS, resolveLandlordPlan } from '@/lib/plans'
 
 // 매물 생성/수정 스키마
 const propertySchema = z.object({
@@ -165,6 +166,24 @@ export async function POST(request: Request) {
 
     if (userResult.length === 0 || userResult[0].user_type !== 'landlord') {
       return NextResponse.json({ error: '집주인만 접근할 수 있습니다' }, { status: 403 })
+    }
+
+    // Enforce the plan's listing limit server-side (the client-facing counts
+    // were display-only; creation was previously unlimited on any plan).
+    const plan = await resolveLandlordPlan(payload.userId)
+    const maxProperties = PLAN_LIMITS[plan].maxProperties
+    const countRow = await query<{ count: string }>(
+      'SELECT COUNT(*) AS count FROM properties WHERE landlord_id = $1',
+      [payload.userId]
+    )
+    if (Number(countRow[0]?.count ?? 0) >= maxProperties) {
+      return NextResponse.json(
+        {
+          error: `${PLAN_LIMITS[plan].label} 플랜은 매물을 최대 ${maxProperties}개까지 등록할 수 있습니다. 플랜을 업그레이드해주세요.`,
+          code: 'PLAN_LIMIT_REACHED',
+        },
+        { status: 403 }
+      )
     }
 
     const body = await request.json()

--- a/app/api/landlord/subscription/route.ts
+++ b/app/api/landlord/subscription/route.ts
@@ -3,6 +3,7 @@ import { query, queryOne } from '@/lib/db'
 import { getCurrentUser } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { isStripeEnabled } from '@/lib/stripe'
+import { PLAN_LIMITS } from '@/lib/plans'
 
 interface Subscription {
   id: string
@@ -10,19 +11,6 @@ interface Subscription {
   started_at: string
   expires_at: string | null
   is_active: boolean
-}
-
-interface PlanLimits {
-  maxProperties: number
-  maxFeatured: number
-  label: string
-  price: number
-}
-
-const PLAN_LIMITS: Record<string, PlanLimits> = {
-  free:  { maxProperties: 3,   maxFeatured: 0, label: '무료',      price: 0 },
-  basic: { maxProperties: 10,  maxFeatured: 2, label: '베이직',    price: 19900 },
-  pro:   { maxProperties: 999, maxFeatured: 5, label: '프로',      price: 49900 },
 }
 
 /**
@@ -115,7 +103,21 @@ export async function POST(request: Request) {
       )
     }
 
-    // Stripe 미설정: 데모 모드 (즉시 적용)
+    // Never grant a paid plan for free in production. If Stripe is unconfigured
+    // there it is a misconfiguration — fail closed instead of handing out
+    // entitlements without payment.
+    if (process.env.NODE_ENV === 'production') {
+      logger.error('Paid subscription requested but Stripe is not configured in production', {
+        landlordId: user.id,
+        plan,
+      })
+      return NextResponse.json(
+        { error: '결제 시스템이 준비되지 않았습니다. 잠시 후 다시 시도해주세요.', code: 'PAYMENTS_UNAVAILABLE' },
+        { status: 503 }
+      )
+    }
+
+    // Stripe 미설정 (비프로덕션): 데모 모드 (즉시 적용)
     await query(
       'UPDATE landlord_subscriptions SET is_active = false WHERE landlord_id = $1',
       [user.id]

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -99,8 +99,10 @@ async function handleCheckoutComplete(session: Stripe.Checkout.Session) {
         )
       : { rows: [] as { id: string }[] }
 
-    const expiresAt =
-      typeof session.expires_at === 'number' ? new Date(session.expires_at * 1000).toISOString() : getDefaultExpiresAt()
+    // Use the SUBSCRIPTION's billing-period end, not session.expires_at (which
+    // is the checkout link's own ~24h expiry — using it made every paid plan
+    // lapse a day after payment).
+    const expiresAt = await resolveSubscriptionExpiry(paymentRef)
 
     if (existingByRef.rows.length > 0) {
       const targetId = existingByRef.rows[0].id
@@ -155,14 +157,31 @@ async function handleCheckoutComplete(session: Stripe.Checkout.Session) {
   })
 }
 
-async function handleSubscriptionUpdate(subscription: Stripe.Subscription) {
+function subscriptionPeriodEnd(subscription: Stripe.Subscription): string | null {
   const currentPeriodEnd = subscription.items.data.reduce<number | null>(
-    (latest, item) => latest === null ? item.current_period_end : Math.max(latest, item.current_period_end),
+    (latest, item) => (latest === null ? item.current_period_end : Math.max(latest, item.current_period_end)),
     null
   )
-  const periodEnd = currentPeriodEnd !== null
-    ? new Date(currentPeriodEnd * 1000).toISOString()
-    : null
+  return currentPeriodEnd !== null ? new Date(currentPeriodEnd * 1000).toISOString() : null
+}
+
+// Resolve a subscription's real billing-period end for `expires_at`. Falls back
+// to a default only if the subscription can't be retrieved.
+async function resolveSubscriptionExpiry(subscriptionId: string | null): Promise<string> {
+  if (subscriptionId && stripe) {
+    try {
+      const sub = await stripe.subscriptions.retrieve(subscriptionId)
+      const end = subscriptionPeriodEnd(sub)
+      if (end) return end
+    } catch (error) {
+      logger.error('Failed to retrieve subscription for expiry', { subscriptionId, error })
+    }
+  }
+  return getDefaultExpiresAt()
+}
+
+async function handleSubscriptionUpdate(subscription: Stripe.Subscription) {
+  const periodEnd = subscriptionPeriodEnd(subscription)
   const isActive = subscription.status === 'active'
 
   const result = await query<{ id: string }>(

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -1,0 +1,30 @@
+import { queryOne } from '@/lib/db'
+
+export interface PlanLimits {
+  maxProperties: number
+  maxFeatured: number
+  label: string
+  price: number
+}
+
+export type PlanName = 'free' | 'basic' | 'pro'
+
+export const PLAN_LIMITS: Record<string, PlanLimits> = {
+  free: { maxProperties: 3, maxFeatured: 0, label: '무료', price: 0 },
+  basic: { maxProperties: 10, maxFeatured: 2, label: '베이직', price: 19900 },
+  pro: { maxProperties: 999, maxFeatured: 5, label: '프로', price: 49900 },
+}
+
+/** The landlord's currently active plan (defaults to 'free' when none is active). */
+export async function resolveLandlordPlan(landlordId: string): Promise<PlanName> {
+  const sub = await queryOne<{ plan: PlanName }>(
+    `SELECT plan FROM landlord_subscriptions
+      WHERE landlord_id = $1
+        AND is_active = true
+        AND (expires_at IS NULL OR expires_at > NOW())
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [landlordId]
+  )
+  return sub?.plan ?? 'free'
+}


### PR DESCRIPTION
Three entitlement fixes: (1) expires_at from the subscription period not the ~24h checkout-link expiry; (2) server-side PLAN_LIMITS.maxProperties enforcement on property create (was unlimited); (3) no free paid-plan grants via demo fallback in production. 🤖 Generated with [Claude Code](https://claude.com/claude-code)