### PR TITLE
fix(security): prevent trust-evidence self-certification forgery

### DIFF
--- a/app/api/v1/evidence/route.ts
+++ b/app/api/v1/evidence/route.ts
@@ -1,10 +1,16 @@
 import { z } from 'zod'
 import { getCurrentUser } from '@/lib/auth'
+import { queryOne } from '@/lib/db'
 import { createEvidenceFact } from '@/lib/trust-engine'
 import { getRequestContext } from '@/lib/request-context'
 import { getClientIp } from '@/lib/rate-limit'
 import { jsonError, jsonSuccess } from '@/lib/api-response'
 import { withIdempotency } from '@/lib/idempotency'
+
+// Sources a non-admin caller may self-submit under. Reviewer/operator-grade
+// sources (e.g. human_review, 0.90 reliability) can only be set by admins —
+// clients must never be able to mint "verified" evidence about themselves.
+const SELF_SERVICE_SOURCES = new Set(['user_direct', 'user_upload'])
 
 const schema = z.object({
   subjectType: z.enum(['tenant', 'landlord', 'property']),
@@ -36,12 +42,35 @@ export async function POST(request: Request) {
     handler: async () => {
       const parsed = schema.safeParse(await request.json())
       if (!parsed.success) return jsonError(request, 400, parsed.error.issues[0]?.message ?? 'Invalid payload', 'INVALID_PAYLOAD')
-      if (parsed.data.subjectType !== 'property' && parsed.data.subjectId !== user.id && user.user_type !== 'admin') {
-        return jsonError(request, 403, 'Cannot submit evidence for this subject', 'TRUST_EVIDENCE_FORBIDDEN')
+
+      const data = parsed.data
+      const isAdmin = user.user_type === 'admin'
+
+      if (!isAdmin) {
+        // Authorization: a caller may only submit evidence about themselves or a
+        // property they own. (Previously `property` bypassed all checks, letting
+        // anyone poison any property's trust facts.)
+        if (data.subjectType === 'property') {
+          const owns = await queryOne<{ id: string }>(
+            'SELECT id FROM properties WHERE id = $1 AND landlord_id = $2',
+            [data.subjectId, user.id]
+          )
+          if (!owns) return jsonError(request, 403, 'Cannot submit evidence for this property', 'TRUST_EVIDENCE_FORBIDDEN')
+        } else if (data.subjectId !== user.id) {
+          return jsonError(request, 403, 'Cannot submit evidence for this subject', 'TRUST_EVIDENCE_FORBIDDEN')
+        }
+
+        // Clients cannot self-certify: reject reviewer-grade sources and never
+        // honour a client-supplied humanReviewed flag.
+        if (!SELF_SERVICE_SOURCES.has(data.sourceCode)) {
+          return jsonError(request, 403, 'This evidence source requires operator verification', 'TRUST_SOURCE_FORBIDDEN')
+        }
+        data.humanReviewed = false
       }
+
       try {
         const context = getRequestContext(request)
-        const result = await createEvidenceFact(parsed.data, user.id, { ...context, ip: getClientIp(request) })
+        const result = await createEvidenceFact(data, user.id, { ...context, ip: getClientIp(request) })
         return jsonSuccess(request, result, 201)
       } catch (error) {
         console.error('Trust evidence create failed:', error)


### PR DESCRIPTION
Clients controlled sourceCode + humanReviewed, so anyone could mint 'human-reviewed' verified facts about themselves; property evidence bypassed authz entirely. Now non-admins may only submit about self / owned property, under self-service sources, with humanReviewed forced false. 🤖 Generated with [Claude Code](https://claude.com/claude-code)