### PR TITLE
fix: bound message pagination + redact PII in logs

### DIFF
--- a/app/api/messages/conversations/[id]/route.ts
+++ b/app/api/messages/conversations/[id]/route.ts
@@ -72,8 +72,8 @@ export async function GET(
     const conversation = conversationResult[0]
 
     const { searchParams } = new URL(request.url)
-    const page = parseInt(searchParams.get('page') || '1')
-    const limit = parseInt(searchParams.get('limit') || '50')
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1') || 1)
+    const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') || '50') || 50))
     const offset = (page - 1) * limit
 
     // 메시지 목록 조회 (최신순)

--- a/app/api/messages/conversations/route.ts
+++ b/app/api/messages/conversations/route.ts
@@ -51,8 +51,8 @@ export async function GET(request: Request) {
     }
 
     const { searchParams } = new URL(request.url)
-    const page = parseInt(searchParams.get('page') || '1')
-    const limit = parseInt(searchParams.get('limit') || '20')
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1') || 1)
+    const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') || '20') || 20))
     const offset = (page - 1) * limit
 
     // 사용자의 대화방 목록 조회 (집주인 또는 세입자)

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -19,17 +19,56 @@ function formatError(error: unknown): Record<string, unknown> | undefined {
   return { raw: String(error) }
 }
 
+// Keys whose values are PII/secrets and must never reach the log sink in the
+// clear (PIPA). Masking is centralized here so every logger caller is covered.
+const SENSITIVE_KEYS = new Set([
+  'phone', 'phonenumber', 'email', 'otp', 'code', 'verificationcode',
+  'password', 'token', 'accesstoken', 'refreshtoken', 'authorization',
+  'ssn', 'residentnumber', 'residentregistrationnumber', 'accountnumber',
+])
+
+function maskValue(key: string, value: string): string {
+  const k = key.toLowerCase()
+  if (k === 'email') {
+    const at = value.indexOf('@')
+    return at > 0 ? `${value.slice(0, 1)}***${value.slice(at)}` : '***'
+  }
+  if (k === 'phone' || k === 'phonenumber') {
+    return value.length > 4 ? `***${value.slice(-4)}` : '***'
+  }
+  return '***'
+}
+
+function redactPii(meta: Record<string, unknown>, depth = 0): Record<string, unknown> {
+  if (depth > 4) return meta
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(meta)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      out[key] = typeof value === 'string' && value.length > 0 ? maskValue(key, value) : '***'
+    } else if (value && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Error)) {
+      out[key] = redactPii(value as Record<string, unknown>, depth + 1)
+    } else {
+      out[key] = value
+    }
+  }
+  return out
+}
+
 function log(level: LogLevel, message: string, meta?: Record<string, unknown>) {
+  let processedMeta = meta
+  // meta에 error가 있으면 포맷팅
+  if (meta?.error) {
+    processedMeta = { ...meta, error: formatError(meta.error) }
+  }
+  if (processedMeta) {
+    processedMeta = redactPii(processedMeta)
+  }
+
   const entry: LogEntry = {
     level,
     message,
-    meta,
+    meta: processedMeta,
     timestamp: new Date().toISOString(),
-  }
-
-  // meta에 error가 있으면 포맷팅
-  if (meta?.error) {
-    entry.meta = { ...meta, error: formatError(meta.error) }
   }
 
   if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
Clamp page/limit (1..50) on both messaging routes (was unbounded → DoS; NaN/negative → 500). Centralize PII masking in lib/logger (phone/email/otp/tokens) so structured logs no longer leak PII. 🤖 Generated with [Claude Code](https://claude.com/claude-code)