### PR TITLE
fix(privacy): complete account-deletion PII erasure + policy contact

### DIFF
--- a/app/api/account/delete/route.ts
+++ b/app/api/account/delete/route.ts
@@ -39,6 +39,13 @@ export async function DELETE() {
       await client.query('DELETE FROM notifications WHERE user_id = $1', [userId])
       await client.query('DELETE FROM favorites WHERE user_id = $1', [userId])
 
+      // Sensitive verification data (소득·재직·신용) must be erased, not retained.
+      await client.query('DELETE FROM verifications WHERE user_id = $1', [userId])
+
+      // Landlord references this tenant collected hold third-party contact PII
+      // (landlord name/phone/email); reference_responses cascade via FK.
+      await client.query('DELETE FROM landlord_references WHERE user_id = $1', [userId])
+
       await client.query(
         `UPDATE tenant_profiles
          SET workplace = NULL,

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -86,7 +86,7 @@ export default function PrivacyPage() {
             <p>
               개인정보 보호와 관련한 문의는 아래 연락처로 문의해 주시기 바랍니다.
             </p>
-            <p>이메일: privacy@rentme.kr</p>
+            <p>이메일: privacy@ipjuhae.com</p>
           </section>
 
           <p className="text-xs text-muted-foreground pt-4 border-t">


### PR DESCRIPTION
Account deletion now also erases verifications (income/employment/credit) and landlord_references (3rd-party contact PII; responses cascade), matching the '즉시 파기' policy. Privacy policy contact corrected to privacy@ipjuhae.com. (Officer name must be filled by a human.) 🤖 Generated with [Claude Code](https://claude.com/claude-code)