### PR TITLE
feat(community): role-segmented community boards

### DIFF
--- a/app/api/community/posts/[id]/comments/route.ts
+++ b/app/api/community/posts/[id]/comments/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getCurrentUser } from '@/lib/auth'
+import { query, queryOne, transaction } from '@/lib/db'
+import { sanitizeUserInput } from '@/lib/sanitize'
+import { logger } from '@/lib/logger'
+import { readableAudiences, type CommunityAudience } from '@/lib/community'
+
+interface CommentRow {
+  id: string
+  author_id: string
+  body: string
+  created_at: string
+  author_name: string | null
+}
+
+async function loadReadablePost(postId: string, userType: string | null, userId: string) {
+  const post = await queryOne<{ id: string; audience: CommunityAudience; author_id: string }>(
+    'SELECT id, audience, author_id FROM community_posts WHERE id = $1 AND deleted_at IS NULL',
+    [postId]
+  )
+  if (!post) return { post: null, allowed: false }
+  const allowed = post.author_id === userId || readableAudiences(userType).includes(post.audience)
+  return { post, allowed }
+}
+
+// GET /api/community/posts/[id]/comments
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: '로그인이 필요합니다' }, { status: 401 })
+
+  const { id } = await params
+  const { post, allowed } = await loadReadablePost(id, user.user_type, user.id)
+  if (!post) return NextResponse.json({ error: '게시글을 찾을 수 없습니다' }, { status: 404 })
+  if (!allowed) return NextResponse.json({ error: '접근할 수 없는 게시글입니다' }, { status: 403 })
+
+  try {
+    const comments = await query<CommentRow>(
+      `SELECT c.id, c.author_id, c.body, c.created_at,
+              COALESCE(pr.name, u.name) AS author_name
+         FROM community_comments c
+         JOIN users u ON u.id = c.author_id
+         LEFT JOIN profiles pr ON pr.user_id = c.author_id
+        WHERE c.post_id = $1 AND c.deleted_at IS NULL
+        ORDER BY c.created_at ASC
+        LIMIT 200`,
+      [id]
+    )
+    return NextResponse.json({ comments })
+  } catch (error) {
+    logger.error('댓글 조회 오류', { error })
+    return NextResponse.json({ error: '댓글을 불러오지 못했습니다' }, { status: 500 })
+  }
+}
+
+const createSchema = z.object({ body: z.string().min(1, '내용을 입력해주세요').max(2000) })
+
+// POST /api/community/posts/[id]/comments
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: '로그인이 필요합니다' }, { status: 401 })
+
+  const { id } = await params
+  const { post, allowed } = await loadReadablePost(id, user.user_type, user.id)
+  if (!post) return NextResponse.json({ error: '게시글을 찾을 수 없습니다' }, { status: 404 })
+  if (!allowed) return NextResponse.json({ error: '접근할 수 없는 게시글입니다' }, { status: 403 })
+
+  const parsed = createSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? '잘못된 입력입니다' }, { status: 400 })
+  }
+
+  try {
+    const comment = await transaction(async (client) => {
+      const inserted = await client.query<{ id: string }>(
+        'INSERT INTO community_comments (post_id, author_id, body) VALUES ($1, $2, $3) RETURNING id',
+        [id, user.id, sanitizeUserInput(parsed.data.body)]
+      )
+      await client.query('UPDATE community_posts SET comment_count = comment_count + 1 WHERE id = $1', [id])
+      return inserted.rows[0]
+    })
+    return NextResponse.json({ id: comment?.id }, { status: 201 })
+  } catch (error) {
+    logger.error('댓글 작성 오류', { error })
+    return NextResponse.json({ error: '댓글 작성에 실패했습니다' }, { status: 500 })
+  }
+}

--- a/app/api/community/posts/[id]/route.ts
+++ b/app/api/community/posts/[id]/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth'
+import { query, queryOne } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { readableAudiences, type CommunityAudience } from '@/lib/community'
+
+interface PostRow {
+  id: string
+  author_id: string
+  audience: CommunityAudience
+  category: string | null
+  title: string
+  body: string
+  view_count: number
+  comment_count: number
+  created_at: string
+  author_name: string | null
+}
+
+// GET /api/community/posts/[id]
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: '로그인이 필요합니다' }, { status: 401 })
+
+  const { id } = await params
+  try {
+    const post = await queryOne<PostRow>(
+      `SELECT p.id, p.author_id, p.audience, p.category, p.title, p.body,
+              p.view_count, p.comment_count, p.created_at,
+              COALESCE(pr.name, u.name) AS author_name
+         FROM community_posts p
+         JOIN users u ON u.id = p.author_id
+         LEFT JOIN profiles pr ON pr.user_id = p.author_id
+        WHERE p.id = $1 AND p.deleted_at IS NULL`,
+      [id]
+    )
+    if (!post) return NextResponse.json({ error: '게시글을 찾을 수 없습니다' }, { status: 404 })
+
+    const isAuthor = post.author_id === user.id
+    if (!isAuthor && !readableAudiences(user.user_type).includes(post.audience)) {
+      return NextResponse.json({ error: '접근할 수 없는 게시글입니다' }, { status: 403 })
+    }
+
+    // best-effort view count
+    await query('UPDATE community_posts SET view_count = view_count + 1 WHERE id = $1', [id]).catch(() => undefined)
+
+    return NextResponse.json({ post: { ...post, is_author: isAuthor } })
+  } catch (error) {
+    logger.error('커뮤니티 상세 조회 오류', { error })
+    return NextResponse.json({ error: '게시글을 불러오지 못했습니다' }, { status: 500 })
+  }
+}

--- a/app/api/community/posts/route.ts
+++ b/app/api/community/posts/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getCurrentUser } from '@/lib/auth'
+import { query, queryOne } from '@/lib/db'
+import { sanitizeUserInput } from '@/lib/sanitize'
+import { logger } from '@/lib/logger'
+import {
+  canPostTo,
+  isCommunityAudience,
+  readableAudiences,
+  type CommunityAudience,
+} from '@/lib/community'
+
+interface PostRow {
+  id: string
+  author_id: string
+  audience: string
+  category: string | null
+  title: string
+  body: string
+  view_count: number
+  comment_count: number
+  created_at: string
+  author_name: string | null
+}
+
+// GET /api/community/posts?audience=&page=&limit=
+export async function GET(request: Request) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: '로그인이 필요합니다' }, { status: 401 })
+
+  const { searchParams } = new URL(request.url)
+  const requested = searchParams.get('audience')
+  const allowed = readableAudiences(user.user_type)
+
+  let audiences: CommunityAudience[] = allowed
+  if (requested && requested !== 'all_boards') {
+    if (!isCommunityAudience(requested) || !allowed.includes(requested)) {
+      return NextResponse.json({ error: '접근할 수 없는 게시판입니다' }, { status: 403 })
+    }
+    audiences = [requested]
+  }
+
+  const page = Math.max(1, parseInt(searchParams.get('page') || '1') || 1)
+  const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') || '20') || 20))
+  const offset = (page - 1) * limit
+
+  try {
+    const rows = await query<PostRow>(
+      `SELECT p.id, p.author_id, p.audience, p.category, p.title, p.body,
+              p.view_count, p.comment_count, p.created_at,
+              COALESCE(pr.name, u.name) AS author_name
+         FROM community_posts p
+         JOIN users u ON u.id = p.author_id
+         LEFT JOIN profiles pr ON pr.user_id = p.author_id
+        WHERE p.deleted_at IS NULL
+          AND p.audience = ANY($1::text[])
+        ORDER BY p.created_at DESC
+        LIMIT $2 OFFSET $3`,
+      [audiences, limit, offset]
+    )
+    return NextResponse.json({ posts: rows, page, limit, hasMore: rows.length === limit })
+  } catch (error) {
+    logger.error('커뮤니티 목록 조회 오류', { error })
+    return NextResponse.json({ error: '게시글을 불러오지 못했습니다' }, { status: 500 })
+  }
+}
+
+const createSchema = z.object({
+  audience: z.enum(['all', 'tenant', 'landlord', 'broker']),
+  category: z.string().max(40).optional(),
+  title: z.string().min(1, '제목을 입력해주세요').max(200),
+  body: z.string().min(1, '내용을 입력해주세요').max(10000),
+})
+
+// POST /api/community/posts
+export async function POST(request: Request) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: '로그인이 필요합니다' }, { status: 401 })
+
+  const parsed = createSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? '잘못된 입력입니다' }, { status: 400 })
+  }
+  const data = parsed.data
+
+  if (!canPostTo(user.user_type, data.audience)) {
+    return NextResponse.json({ error: '이 게시판에 글을 쓸 수 없습니다' }, { status: 403 })
+  }
+
+  try {
+    const post = await queryOne<{ id: string }>(
+      `INSERT INTO community_posts (author_id, audience, category, title, body)
+       VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+      [
+        user.id,
+        data.audience,
+        data.category ? sanitizeUserInput(data.category) : null,
+        sanitizeUserInput(data.title),
+        sanitizeUserInput(data.body),
+      ]
+    )
+    return NextResponse.json({ id: post?.id }, { status: 201 })
+  } catch (error) {
+    logger.error('커뮤니티 작성 오류', { error })
+    return NextResponse.json({ error: '게시글 작성에 실패했습니다' }, { status: 500 })
+  }
+}

--- a/app/community/[id]/page.tsx
+++ b/app/community/[id]/page.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { use, useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Header } from '@/components/layout/header'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Textarea } from '@/components/ui/textarea'
+import { Spinner } from '@/components/ui/spinner'
+import { AUDIENCE_LABELS, type CommunityAudience } from '@/lib/community'
+
+interface Post {
+  id: string
+  audience: CommunityAudience
+  title: string
+  body: string
+  view_count: number
+  comment_count: number
+  created_at: string
+  author_name: string | null
+}
+interface Comment {
+  id: string
+  body: string
+  created_at: string
+  author_name: string | null
+}
+
+export default function CommunityPostPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  const router = useRouter()
+  const [post, setPost] = useState<Post | null>(null)
+  const [comments, setComments] = useState<Comment[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [body, setBody] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/community/posts/${id}`)
+      if (res.status === 401) { router.push(`/login?redirect=/community/${id}`); return }
+      if (!res.ok) { setError((await res.json().catch(() => null))?.error ?? '게시글을 불러오지 못했습니다'); return }
+      setPost((await res.json()).post)
+      const cRes = await fetch(`/api/community/posts/${id}/comments`)
+      if (cRes.ok) setComments((await cRes.json()).comments ?? [])
+    } finally {
+      setLoading(false)
+    }
+  }, [id, router])
+
+  useEffect(() => { load() }, [load])
+
+  async function submitComment() {
+    if (!body.trim()) return
+    setSubmitting(true)
+    try {
+      const res = await fetch(`/api/community/posts/${id}/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body }),
+      })
+      if (res.ok) { setBody(''); load() }
+      else alert((await res.json().catch(() => null))?.error ?? '댓글 작성 실패')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-muted/40">
+      <Header />
+      <main className="container mx-auto max-w-3xl px-4 py-8">
+        <Link href="/community" className="mb-4 inline-block text-sm text-muted-foreground hover:text-foreground">← 커뮤니티</Link>
+
+        {loading ? (
+          <div className="flex justify-center py-16"><Spinner /></div>
+        ) : error ? (
+          <Card className="p-6 text-center text-muted-foreground">{error}</Card>
+        ) : post ? (
+          <>
+            <Card className="mb-6 p-5">
+              <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground">
+                <span className="rounded bg-secondary px-1.5 py-0.5 text-secondary-foreground">{AUDIENCE_LABELS[post.audience]}</span>
+                <span>{post.author_name ?? '익명'}</span>
+              </div>
+              <h1 className="text-xl font-bold">{post.title}</h1>
+              <p className="mt-3 whitespace-pre-wrap text-sm leading-7">{post.body}</p>
+            </Card>
+
+            <h2 className="mb-3 text-sm font-semibold">댓글 {comments.length}</h2>
+            <ul className="mb-5 space-y-3">
+              {comments.map((c) => (
+                <li key={c.id} className="rounded-lg border bg-background p-3">
+                  <p className="mb-1 text-xs text-muted-foreground">{c.author_name ?? '익명'}</p>
+                  <p className="whitespace-pre-wrap text-sm">{c.body}</p>
+                </li>
+              ))}
+            </ul>
+
+            <div className="space-y-2">
+              <Textarea placeholder="댓글을 입력하세요" value={body} onChange={(e) => setBody(e.target.value)} rows={3} maxLength={2000} />
+              <div className="flex justify-end">
+                <Button onClick={submitComment} disabled={submitting || !body.trim()}>
+                  {submitting ? '등록 중…' : '댓글 등록'}
+                </Button>
+              </div>
+            </div>
+          </>
+        ) : null}
+      </main>
+    </div>
+  )
+}

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Header } from '@/components/layout/header'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Spinner } from '@/components/ui/spinner'
+import { EmptyState } from '@/components/ui/empty-state'
+import { MessageSquare } from 'lucide-react'
+import {
+  AUDIENCE_LABELS,
+  canPostTo,
+  readableAudiences,
+  userTypeToAudience,
+  type CommunityAudience,
+} from '@/lib/community'
+
+interface Post {
+  id: string
+  audience: CommunityAudience
+  category: string | null
+  title: string
+  comment_count: number
+  view_count: number
+  created_at: string
+  author_name: string | null
+}
+
+export default function CommunityPage() {
+  const router = useRouter()
+  const [userType, setUserType] = useState<string | null>(null)
+  const [ready, setReady] = useState(false)
+  const [tab, setTab] = useState<CommunityAudience>('all')
+  const [posts, setPosts] = useState<Post[]>([])
+  const [loading, setLoading] = useState(false)
+  const [writing, setWriting] = useState(false)
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [audience, setAudience] = useState<CommunityAudience>('all')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/auth/me')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setUserType(d?.user?.userType ?? null))
+      .catch(() => setUserType(null))
+      .finally(() => setReady(true))
+  }, [])
+
+  const tabs = readableAudiences(userType)
+
+  const load = useCallback(async (aud: CommunityAudience) => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/community/posts?audience=${aud}`)
+      if (res.status === 401) {
+        router.push('/login?redirect=/community')
+        return
+      }
+      const data = await res.json()
+      setPosts(data.posts ?? [])
+    } finally {
+      setLoading(false)
+    }
+  }, [router])
+
+  useEffect(() => {
+    if (ready) load(tab)
+  }, [ready, tab, load])
+
+  const ownAudience = userTypeToAudience(userType)
+
+  async function submit() {
+    if (!title.trim() || !body.trim()) return
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/community/posts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ audience, title, body }),
+      })
+      if (res.ok) {
+        setTitle('')
+        setBody('')
+        setWriting(false)
+        load(tab)
+      } else {
+        const d = await res.json().catch(() => null)
+        alert(d?.error ?? '작성에 실패했습니다')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-muted/40">
+      <Header />
+      <main className="container mx-auto max-w-3xl px-4 py-8">
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">커뮤니티</h1>
+            <p className="text-sm text-muted-foreground">임차인·임대인·공인중개사가 정보를 나누는 공간</p>
+          </div>
+          <Button onClick={() => { setAudience(ownAudience ?? 'all'); setWriting((v) => !v) }}>
+            글쓰기
+          </Button>
+        </div>
+
+        <div className="mb-5 flex flex-wrap gap-2">
+          {tabs.map((a) => (
+            <button
+              key={a}
+              onClick={() => setTab(a)}
+              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                tab === a ? 'bg-primary text-primary-foreground' : 'bg-background text-muted-foreground hover:bg-muted'
+              }`}
+            >
+              {AUDIENCE_LABELS[a]}
+            </button>
+          ))}
+        </div>
+
+        {writing && (
+          <Card className="mb-6 space-y-3 p-4">
+            <div className="flex flex-wrap gap-2">
+              {tabs.filter((a) => canPostTo(userType, a)).map((a) => (
+                <button
+                  key={a}
+                  onClick={() => setAudience(a)}
+                  className={`rounded-md px-3 py-1 text-xs font-medium ${
+                    audience === a ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+                  }`}
+                >
+                  {AUDIENCE_LABELS[a]} 게시판
+                </button>
+              ))}
+            </div>
+            <Input placeholder="제목" value={title} onChange={(e) => setTitle(e.target.value)} maxLength={200} />
+            <Textarea placeholder="내용을 입력하세요" value={body} onChange={(e) => setBody(e.target.value)} rows={5} maxLength={10000} />
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setWriting(false)}>취소</Button>
+              <Button onClick={submit} disabled={submitting || !title.trim() || !body.trim()}>
+                {submitting ? '등록 중…' : '등록'}
+              </Button>
+            </div>
+          </Card>
+        )}
+
+        {loading ? (
+          <div className="flex justify-center py-16"><Spinner /></div>
+        ) : posts.length === 0 ? (
+          <EmptyState icon={<MessageSquare className="h-10 w-10" />} title="아직 글이 없어요" description="첫 글을 남겨보세요." />
+        ) : (
+          <ul className="space-y-3">
+            {posts.map((p) => (
+              <li key={p.id}>
+                <Link href={`/community/${p.id}`}>
+                  <Card className="p-4 transition-shadow hover:shadow-card">
+                    <div className="mb-1 flex items-center gap-2 text-xs text-muted-foreground">
+                      <span className="rounded bg-secondary px-1.5 py-0.5 text-secondary-foreground">
+                        {AUDIENCE_LABELS[p.audience]}
+                      </span>
+                      <span>{p.author_name ?? '익명'}</span>
+                    </div>
+                    <p className="font-semibold">{p.title}</p>
+                    <div className="mt-1 flex gap-3 text-xs text-muted-foreground">
+                      <span>댓글 {p.comment_count}</span>
+                      <span>조회 {p.view_count}</span>
+                    </div>
+                  </Card>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -24,6 +24,7 @@ const tenantLinks = [
   { href: '/profile/consent/events', label: 'Consent Events' },
   { href: '/profile/access-logs', label: 'Access Logs' },
   { href: '/messages', label: 'Messages' },
+  { href: '/community', label: '커뮤니티' },
 ]
 
 const landlordLinks = [
@@ -32,6 +33,7 @@ const landlordLinks = [
   { href: '/landlord/properties', label: 'Properties' },
   { href: '/landlord/favorites', label: 'Favorites' },
   { href: '/landlord/messages', label: 'Messages' },
+  { href: '/community', label: '커뮤니티' },
   { href: '/landlord/subscription', label: 'Subscription' },
   { href: '/profile/consent', label: 'Consent' },
   { href: '/profile/consent/events', label: 'Consent Events' },

--- a/db/migrate.ts
+++ b/db/migrate.ts
@@ -46,6 +46,7 @@ const migrations = [
   'migration-029-compliance-gate-audit.sql',
   'migration-030-trust-stage-performance.sql',
   'migration-031-trust-disclosure-matrix.sql',
+  'migration-032-community.sql',
 ] as const
 
 const args = process.argv.slice(2)

--- a/db/migration-032-community.sql
+++ b/db/migration-032-community.sql
@@ -1,0 +1,35 @@
+-- Migration 032: role-segmented community (임차인/임대인/공인중개사/전체)
+-- Boards are scoped by audience; a user reads the shared 'all' board plus the
+-- board for their own role, and may post to 'all' or their own role's board.
+
+CREATE TABLE IF NOT EXISTS community_posts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  audience VARCHAR(20) NOT NULL DEFAULT 'all',
+  category VARCHAR(40),
+  title VARCHAR(200) NOT NULL,
+  body TEXT NOT NULL,
+  view_count INT NOT NULL DEFAULT 0,
+  comment_count INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ,
+  CONSTRAINT ck_community_audience CHECK (audience IN ('all', 'tenant', 'landlord', 'broker'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_community_posts_audience
+  ON community_posts (audience, created_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_community_posts_author
+  ON community_posts (author_id);
+
+CREATE TABLE IF NOT EXISTS community_comments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id UUID NOT NULL REFERENCES community_posts(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  body TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_community_comments_post
+  ON community_comments (post_id, created_at) WHERE deleted_at IS NULL;

--- a/lib/community.ts
+++ b/lib/community.ts
@@ -1,0 +1,34 @@
+export type CommunityAudience = 'all' | 'tenant' | 'landlord' | 'broker'
+
+export const COMMUNITY_AUDIENCES: CommunityAudience[] = ['all', 'tenant', 'landlord', 'broker']
+
+export const AUDIENCE_LABELS: Record<CommunityAudience, string> = {
+  all: '전체',
+  tenant: '임차인',
+  landlord: '임대인',
+  broker: '공인중개사',
+}
+
+export function isCommunityAudience(value: unknown): value is CommunityAudience {
+  return typeof value === 'string' && (COMMUNITY_AUDIENCES as string[]).includes(value)
+}
+
+/** The board that corresponds to a user's own role (null for admin/unknown). */
+export function userTypeToAudience(userType: string | null | undefined): CommunityAudience | null {
+  if (userType === 'tenant' || userType === 'landlord' || userType === 'broker') return userType
+  return null
+}
+
+/** Audiences a user may READ: the shared board plus their own role's board. */
+export function readableAudiences(userType: string | null | undefined): CommunityAudience[] {
+  if (userType === 'admin') return [...COMMUNITY_AUDIENCES]
+  const role = userTypeToAudience(userType)
+  return role ? ['all', role] : ['all']
+}
+
+/** Whether a user may POST to a given board. */
+export function canPostTo(userType: string | null | undefined, audience: CommunityAudience): boolean {
+  if (userType === 'admin') return true
+  const role = userTypeToAudience(userType)
+  return audience === 'all' || audience === role
+}


### PR DESCRIPTION
Members-only community with boards per audience (전체/임차인/임대인/공인중개사). Reader sees shared + own-role board; posts scoped by role. migration-032 + /api/community/* + /community pages + nav links. 🤖 Generated with [Claude Code](https://claude.com/claude-code)