### PR TITLE
feat(trust): trust nav exposure + transaction registration UI

### DIFF
--- a/app/trust/transactions/[id]/page.tsx
+++ b/app/trust/transactions/[id]/page.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { use, useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Header } from '@/components/layout/header'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
+
+interface Txn { id: string; stage: string | null; terms: Record<string, unknown> | null; created_at: string }
+interface Rec { id: string; recommendation_type?: string; title?: string; detail?: string; body?: string; severity?: string }
+
+export default function TransactionDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  const router = useRouter()
+  const [txn, setTxn] = useState<Txn | null>(null)
+  const [recs, setRecs] = useState<Rec[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [generating, setGenerating] = useState(false)
+  const [note, setNote] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/v1/transactions/${id}`, { cache: 'no-store' })
+      if (res.status === 401) { router.push(`/login?redirect=/trust/transactions/${id}`); return }
+      if (!res.ok) { setError('거래를 찾을 수 없습니다'); return }
+      setTxn((await res.json()).transaction)
+      const rRes = await fetch(`/api/v1/recommendations/${id}`, { cache: 'no-store' })
+      if (rRes.ok) setRecs((await rRes.json()).recommendations ?? [])
+    } finally {
+      setLoading(false)
+    }
+  }, [id, router])
+
+  useEffect(() => { load() }, [load])
+
+  async function generate() {
+    setGenerating(true); setNote(null)
+    try {
+      const res = await fetch(`/api/v1/recommendations/${id}`, { method: 'POST' })
+      if (res.status === 503) {
+        setNote('거래조건 자동 분석은 관리자 승인(공정성·법무 검토) 후 이용할 수 있어요.')
+      } else if (res.ok) {
+        load()
+      } else {
+        setNote((await res.json().catch(() => null))?.error ?? '분석에 실패했습니다')
+      }
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  const terms = txn?.terms ?? {}
+
+  return (
+    <div className="min-h-screen bg-muted/40">
+      <Header />
+      <main className="container mx-auto max-w-3xl px-4 py-8">
+        <Link href="/trust/transactions" className="mb-4 inline-block text-sm text-muted-foreground hover:text-foreground">← 거래 목록</Link>
+
+        {loading ? (
+          <div className="flex justify-center py-16"><Spinner /></div>
+        ) : error ? (
+          <Card className="p-6 text-center text-muted-foreground">{error}</Card>
+        ) : txn ? (
+          <>
+            <Card className="mb-6 p-5">
+              <h1 className="text-xl font-bold">{(terms.address as string) || '거래'}</h1>
+              <dl className="mt-3 grid grid-cols-2 gap-3 text-sm">
+                {terms.deposit != null && <div><dt className="text-muted-foreground">보증금</dt><dd className="font-medium">{String(terms.deposit)}만원</dd></div>}
+                {terms.monthlyRent != null && <div><dt className="text-muted-foreground">월세</dt><dd className="font-medium">{String(terms.monthlyRent)}만원</dd></div>}
+                {terms.plannedContractDate ? <div><dt className="text-muted-foreground">계약 예정일</dt><dd className="font-medium">{String(terms.plannedContractDate)}</dd></div> : null}
+              </dl>
+            </Card>
+
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold">거래조건 · 확인 항목</h2>
+              <Button size="sm" variant="outline" onClick={generate} disabled={generating}>
+                {generating ? '분석 중…' : '거래조건 분석'}
+              </Button>
+            </div>
+            {note && <Card className="mb-3 bg-secondary/50 p-3 text-xs text-secondary-foreground">{note}</Card>}
+            {recs.length === 0 ? (
+              <Card className="p-5 text-sm text-muted-foreground">
+                아직 도출된 거래조건·확인 항목이 없어요. 증빙을 등록하고 분석을 실행하면 보증금·보증보험·추가서류 등 확인 항목이 만들어집니다.
+              </Card>
+            ) : (
+              <ul className="space-y-2">
+                {recs.map((r) => (
+                  <li key={r.id}>
+                    <Card className="p-4">
+                      <p className="text-sm font-semibold">{r.title ?? r.recommendation_type ?? '확인 항목'}</p>
+                      {(r.detail || r.body) && <p className="mt-1 text-sm text-muted-foreground">{r.detail ?? r.body}</p>}
+                    </Card>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="mt-6 rounded-lg border bg-background p-4 text-sm text-muted-foreground">
+              내 신뢰 상태와 검증 근거는 <Link href="/trust-center" className="text-primary underline">신뢰센터</Link>에서 확인할 수 있어요.
+            </div>
+          </>
+        ) : null}
+      </main>
+    </div>
+  )
+}

--- a/app/trust/transactions/page.tsx
+++ b/app/trust/transactions/page.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Header } from '@/components/layout/header'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/spinner'
+import { EmptyState } from '@/components/ui/empty-state'
+import { FileText } from 'lucide-react'
+
+interface Me { id: string; userType: string | null }
+interface Txn {
+  id: string
+  stage: string | null
+  terms: Record<string, unknown> | null
+  created_at: string
+}
+
+const STAGE_LABEL: Record<string, string> = {
+  pre_application: '신청 전', S0: '신청 전',
+  application: '신청', S1: '신청',
+  negotiation: '협의', S2: '협의',
+  contract: '계약', S3: '계약', S4: '계약', S5: '계약', S6: '계약',
+  completed: '완료', S7: '완료', S8: '완료',
+  cancelled: '취소',
+}
+
+function roleField(userType: string | null): 'tenantId' | 'landlordId' | 'realtorId' | null {
+  if (userType === 'tenant') return 'tenantId'
+  if (userType === 'landlord') return 'landlordId'
+  if (userType === 'broker') return 'realtorId'
+  return null
+}
+
+export default function TransactionsPage() {
+  const router = useRouter()
+  const [me, setMe] = useState<Me | null>(null)
+  const [ready, setReady] = useState(false)
+  const [txns, setTxns] = useState<Txn[]>([])
+  const [loading, setLoading] = useState(true)
+  const [open, setOpen] = useState(false)
+  const [address, setAddress] = useState('')
+  const [deposit, setDeposit] = useState('')
+  const [rent, setRent] = useState('')
+  const [date, setDate] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/auth/me')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setMe(d?.user ?? null))
+      .finally(() => setReady(true))
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/v1/transactions', { cache: 'no-store' })
+      if (res.status === 401) { router.push('/login?redirect=/trust/transactions'); return }
+      const data = await res.json()
+      setTxns(data.transactions ?? [])
+    } finally {
+      setLoading(false)
+    }
+  }, [router])
+
+  useEffect(() => { if (ready) load() }, [ready, load])
+
+  const field = roleField(me?.userType ?? null)
+
+  async function submit() {
+    if (!me || !field || !address.trim()) return
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/v1/transactions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          [field]: me.id,
+          stage: 'pre_application',
+          terms: {
+            address: address.trim(),
+            deposit: deposit ? Number(deposit) : null,
+            monthlyRent: rent ? Number(rent) : null,
+            plannedContractDate: date || null,
+          },
+        }),
+      })
+      if (res.ok) {
+        setAddress(''); setDeposit(''); setRent(''); setDate(''); setOpen(false)
+        load()
+      } else {
+        alert((await res.json().catch(() => null))?.error ?? '거래 등록에 실패했습니다')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-muted/40">
+      <Header />
+      <main className="container mx-auto max-w-3xl px-4 py-8">
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">거래</h1>
+            <p className="text-sm text-muted-foreground">계약 전 신뢰 리포트를 만들 거래를 등록하세요.</p>
+          </div>
+          {field && <Button onClick={() => setOpen((v) => !v)}>거래 등록</Button>}
+        </div>
+
+        {open && field && (
+          <Card className="mb-6 space-y-3 p-4">
+            <Input placeholder="주소 (예: 서울시 강남구 …)" value={address} onChange={(e) => setAddress(e.target.value)} />
+            <div className="grid grid-cols-2 gap-3">
+              <Input placeholder="보증금 (만원)" inputMode="numeric" value={deposit} onChange={(e) => setDeposit(e.target.value.replace(/[^0-9]/g, ''))} />
+              <Input placeholder="월세 (만원)" inputMode="numeric" value={rent} onChange={(e) => setRent(e.target.value.replace(/[^0-9]/g, ''))} />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground">계약 예정일</label>
+              <Input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setOpen(false)}>취소</Button>
+              <Button onClick={submit} disabled={submitting || !address.trim()}>{submitting ? '등록 중…' : '등록'}</Button>
+            </div>
+          </Card>
+        )}
+
+        {!field && ready && (
+          <Card className="mb-6 p-4 text-sm text-muted-foreground">
+            거래 등록은 임차인·임대인·공인중개사 계정에서 가능합니다.
+          </Card>
+        )}
+
+        {loading ? (
+          <div className="flex justify-center py-16"><Spinner /></div>
+        ) : txns.length === 0 ? (
+          <EmptyState icon={<FileText className="h-10 w-10" />} title="등록된 거래가 없어요" description="거래를 등록하면 신뢰 리포트를 만들 수 있어요." />
+        ) : (
+          <ul className="space-y-3">
+            {txns.map((t) => (
+              <li key={t.id}>
+                <Link href={`/trust/transactions/${t.id}`}>
+                  <Card className="p-4 transition-shadow hover:shadow-card">
+                    <div className="mb-1 flex items-center gap-2 text-xs text-muted-foreground">
+                      <span className="rounded bg-secondary px-1.5 py-0.5 text-secondary-foreground">
+                        {STAGE_LABEL[t.stage ?? ''] ?? t.stage ?? '진행중'}
+                      </span>
+                      <span>{new Date(t.created_at).toLocaleDateString('ko-KR')}</span>
+                    </div>
+                    <p className="font-semibold">{(t.terms?.address as string) || '주소 미입력'}</p>
+                  </Card>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -24,6 +24,8 @@ const tenantLinks = [
   { href: '/profile/consent/events', label: 'Consent Events' },
   { href: '/profile/access-logs', label: 'Access Logs' },
   { href: '/messages', label: 'Messages' },
+  { href: '/trust-center', label: '신뢰센터' },
+  { href: '/trust/transactions', label: '거래' },
   { href: '/community', label: '커뮤니티' },
 ]
 
@@ -33,6 +35,8 @@ const landlordLinks = [
   { href: '/landlord/properties', label: 'Properties' },
   { href: '/landlord/favorites', label: 'Favorites' },
   { href: '/landlord/messages', label: 'Messages' },
+  { href: '/trust-center', label: '신뢰센터' },
+  { href: '/trust/transactions', label: '거래' },
   { href: '/community', label: '커뮤니티' },
   { href: '/landlord/subscription', label: 'Subscription' },
   { href: '/profile/consent', label: 'Consent' },


### PR DESCRIPTION
Surfaces the trust product (was URL-only): 신뢰센터/거래 nav links + /trust/transactions registration flow (list/register/detail) over /api/v1/transactions + recommendations, with graceful gate-off messaging. 🤖 Generated with [Claude Code](https://claude.com/claude-code)