### PR TITLE
feat(trust): transaction-condition derivation v1

### DIFF
--- a/app/trust/transactions/[id]/page.tsx
+++ b/app/trust/transactions/[id]/page.tsx
@@ -9,7 +9,18 @@ import { Card } from '@/components/ui/card'
 import { Spinner } from '@/components/ui/spinner'
 
 interface Txn { id: string; stage: string | null; terms: Record<string, unknown> | null; created_at: string }
-interface Rec { id: string; recommendation_type?: string; title?: string; detail?: string; body?: string; severity?: string }
+interface Rec { id: string; recommendation_type?: string; value?: Record<string, unknown> | null }
+
+const REC_LABEL: Record<string, string> = {
+  deposit_band: '보증금 노출 검토',
+  insurance_recommendation: '보증보험 권장',
+  special_terms: '표준 특약 확인',
+  additional_evidence: '추가 증빙 필요',
+  insurance_check: '보증보험 확인',
+  deposit_review: '보증금 검토',
+  human_review: '전문가 검토',
+  standard_checklist: '표준 확인 절차',
+}
 
 export default function TransactionDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
@@ -89,14 +100,25 @@ export default function TransactionDetailPage({ params }: { params: Promise<{ id
               </Card>
             ) : (
               <ul className="space-y-2">
-                {recs.map((r) => (
-                  <li key={r.id}>
-                    <Card className="p-4">
-                      <p className="text-sm font-semibold">{r.title ?? r.recommendation_type ?? '확인 항목'}</p>
-                      {(r.detail || r.body) && <p className="mt-1 text-sm text-muted-foreground">{r.detail ?? r.body}</p>}
-                    </Card>
-                  </li>
-                ))}
+                {recs.map((r) => {
+                  const v = r.value ?? {}
+                  const label = (v.label as string) || REC_LABEL[r.recommendation_type ?? ''] || r.recommendation_type || '확인 항목'
+                  const detail = v.detail as string | undefined
+                  const items = Array.isArray(v.items) ? (v.items as string[]) : null
+                  return (
+                    <li key={r.id}>
+                      <Card className="p-4">
+                        <p className="text-sm font-semibold">{label}</p>
+                        {detail && <p className="mt-1 text-sm text-muted-foreground">{detail}</p>}
+                        {items && (
+                          <ul className="mt-2 list-disc space-y-0.5 pl-5 text-sm text-muted-foreground">
+                            {items.map((it, i) => <li key={i}>{it}</li>)}
+                          </ul>
+                        )}
+                      </Card>
+                    </li>
+                  )
+                })}
               </ul>
             )}
 

--- a/lib/trust-engine.ts
+++ b/lib/trust-engine.ts
@@ -1286,6 +1286,58 @@ export async function generateTransactionRecommendations(transactionId: string, 
       recommendations.push({ type: 'human_review', value: { subject_type: score.type, action: 'manual_assessment' }, reasonCodes: ['TRUST_REVIEW_REQUIRED'], dependencies: [score.derivedNodeId] })
     }
   }
+
+  // 거래조건 도출 v1 (잠정 규칙 — 보증금/월세·주택 안전점수 기반; 확정 산식은 추후 교체).
+  // 금액 단위는 만원. 확정 산식/임계값은 법무·변리사 검토 후 대체 예정.
+  const terms = (context.terms as Record<string, unknown> | null) ?? {}
+  const deposit = typeof terms.deposit === 'number' ? terms.deposit : null
+  const monthlyRent = typeof terms.monthlyRent === 'number' ? terms.monthlyRent : null
+  const propertyScore = scores.find((s) => s.type === 'property')?.score ?? null
+  const propertyDerived = scores.find((s) => s.type === 'property')?.derivedNodeId
+
+  if (deposit != null) {
+    const jeonseLike = (monthlyRent ?? 0) <= 10 && deposit >= 3000
+    const band = deposit >= 30000 ? 'high' : deposit >= 10000 ? 'medium' : 'low'
+    recommendations.push({
+      type: 'deposit_band',
+      value: {
+        label: '보증금 노출 검토',
+        detail: `보증금 ${deposit.toLocaleString()}만원 · 노출 ${band === 'high' ? '높음' : band === 'medium' ? '보통' : '낮음'}. ${band === 'low' ? '표준 확인으로 진행하세요.' : '선순위 권리관계·등기부를 계약 당일 재확인하세요.'}`,
+        deposit_manwon: deposit,
+        exposure_band: band,
+      },
+      reasonCodes: ['DEPOSIT_EXPOSURE_BAND'],
+      dependencies: propertyDerived ? [propertyDerived] : [],
+    })
+    if (jeonseLike || (propertyScore != null && propertyScore < 75)) {
+      recommendations.push({
+        type: 'insurance_recommendation',
+        value: {
+          label: '보증보험 가입 권장',
+          detail: jeonseLike
+            ? '전세형(높은 보증금·낮은 월세) 거래로, 전세보증금 반환보증 가입을 권장합니다.'
+            : '주택 안전 점검 결과 보증보험 적격 여부 확인을 권장합니다.',
+          reason: jeonseLike ? 'high_deposit_low_rent' : 'property_safety',
+        },
+        reasonCodes: ['DEPOSIT_GUARANTEE_RECOMMENDED'],
+        dependencies: propertyDerived ? [propertyDerived] : [],
+      })
+    }
+    recommendations.push({
+      type: 'special_terms',
+      value: {
+        label: '표준 특약 확인',
+        items: [
+          '등기부등본 계약 당일 재확인',
+          '선순위 권리관계(근저당·전세권) 확인',
+          deposit >= 10000 ? '전세보증금 반환보증 특약 명시' : '보증금 반환 조건·시점 명시',
+        ],
+      },
+      reasonCodes: ['STANDARD_SPECIAL_TERMS'],
+      dependencies: [],
+    })
+  }
+
   if (recommendations.length === 0) {
     recommendations.push({ type: 'standard_checklist', value: { action: 'continue_with_standard_contract_checks' }, reasonCodes: ['NO_HIGH_RISK_SIGNAL'], dependencies: scores.map((score) => score.derivedNodeId) })
   }


### PR DESCRIPTION
generateTransactionRecommendations now derives concrete 거래조건 from transaction terms — deposit-exposure band, 보증보험 recommendation, standard 특약 checklist (provisional thresholds). Detail UI renders them. Still gated by automated_scoring. 🤖 Generated with [Claude Code](https://claude.com/claude-code)