### PR TITLE
feat(trust): DATA SCORE on the 5 plan criteria

### DIFF
--- a/app/api/v1/data-score/route.ts
+++ b/app/api/v1/data-score/route.ts
@@ -1,0 +1,24 @@
+import { getCurrentUser } from '@/lib/auth'
+import { calculateDataScore } from '@/lib/trust-engine'
+import { jsonError, jsonSuccess } from '@/lib/api-response'
+
+// GET /api/v1/data-score — the caller's own DATA SCORE (evidence quality on the
+// 5 criteria). Not behind the automated_scoring gate: it describes the quality
+// of one's own submitted evidence, not an automated judgment about a person.
+export async function GET(request: Request) {
+  const user = await getCurrentUser()
+  if (!user) return jsonError(request, 401, 'Authentication required', 'AUTH_REQUIRED')
+
+  if (user.user_type !== 'tenant' && user.user_type !== 'landlord') {
+    return jsonError(request, 400, 'No data score for this account type', 'DATA_SCORE_UNAVAILABLE')
+  }
+  const subjectType: 'tenant' | 'landlord' = user.user_type === 'landlord' ? 'landlord' : 'tenant'
+
+  try {
+    const result = await calculateDataScore(subjectType, user.id)
+    return jsonSuccess(request, result)
+  } catch (error) {
+    console.error('Data score failed:', error)
+    return jsonError(request, 500, 'Failed to compute data score', 'DATA_SCORE_FAILED')
+  }
+}

--- a/app/trust-center/page.tsx
+++ b/app/trust-center/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { DataScoreCard } from '@/components/trust/data-score-card'
 import Link from 'next/link'
 import { Header } from '@/components/layout/header'
 import { Button } from '@/components/ui/button'
@@ -93,6 +94,8 @@ export default function TrustCenterPage() {
         </section>
 
         {error ? <div className="mt-6 rounded-2xl border border-red-300 bg-red-50 p-4 text-sm text-red-700">{error}</div> : null}
+
+        <DataScoreCard />
 
         <section className="mt-7 grid gap-4 md:grid-cols-3">
           <Metric

--- a/components/trust/data-score-card.tsx
+++ b/components/trust/data-score-card.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface DataScore {
+  score: number
+  factCount: number
+  dimensions: { clarity: number; completeness: number; recency: number; consistency: number; verifiability: number }
+}
+
+const DIMS: { key: keyof DataScore['dimensions']; label: string }[] = [
+  { key: 'clarity', label: '출처 명확성' },
+  { key: 'completeness', label: '완전성' },
+  { key: 'recency', label: '최신성' },
+  { key: 'consistency', label: '일관성' },
+  { key: 'verifiability', label: '검증 가능성' },
+]
+
+export function DataScoreCard() {
+  const [data, setData] = useState<DataScore | null>(null)
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/v1/data-score', { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (d && typeof d.score === 'number') { setData(d); setShow(true) } })
+      .catch(() => {})
+  }, [])
+
+  if (!show || !data) return null
+
+  return (
+    <section className="mt-7 rounded-2xl border border-[#18342e]/12 bg-[#f8f4e8] p-6">
+      <div className="flex items-end justify-between">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-[#b64d31]">DATA SCORE</p>
+          <p className="mt-1 text-sm text-[#18342e]/70">내 검증 자료의 품질 (출처·완전성·최신성·일관성·검증가능성)</p>
+        </div>
+        <div className="text-right">
+          <span className="text-4xl font-black text-[#18342e]">{data.score}</span>
+          <span className="text-sm text-[#18342e]/60">/100</span>
+        </div>
+      </div>
+      <div className="mt-5 space-y-3">
+        {DIMS.map((d) => {
+          const pct = Math.round((data.dimensions[d.key] ?? 0) * 100)
+          return (
+            <div key={d.key}>
+              <div className="mb-1 flex justify-between text-xs text-[#18342e]/70">
+                <span>{d.label}</span><span>{pct}%</span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-[#18342e]/10">
+                <div className="h-full rounded-full bg-[#de6b48]" style={{ width: `${pct}%` }} />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+      <p className="mt-4 text-xs text-[#18342e]/50">
+        가중치는 파일럿(동일 20%)입니다. 근거 기반 재조정 및 법무 검토 전까지 잠정 지표입니다.
+      </p>
+    </section>
+  )
+}

--- a/lib/trust-engine.ts
+++ b/lib/trust-engine.ts
@@ -1779,3 +1779,70 @@ export async function runTrustMaintenance(trace: RequestTrace = {}) {
     retentionQueued: retentionQueued.length,
   }
 }
+
+const DATA_SCORE_EXPECTED_FIELDS: Record<string, string[]> = {
+  tenant: ['identity_verified', 'employment_verified', 'income_requirement_met', 'credit_verified', 'relationship_verified', 'payment_reliable'],
+  landlord: ['identity_verified', 'ownership_verified', 'registry_clear'],
+  property: ['owner_matched', 'registry_clear', 'senior_claim_safe'],
+}
+
+export interface DataScoreResult {
+  score: number
+  modelVersion: string
+  dimensions: { clarity: number; completeness: number; recency: number; consistency: number; verifiability: number }
+  weights: Record<string, number>
+  factCount: number
+}
+
+// DATA SCORE — evidence-quality metric over the 5 criteria
+// (출처명확성·완전성·최신성·일관성·검증가능성). Pilot uses equal weights. This scores
+// the QUALITY of a subject's evidence, not a judgment about the person, so it is
+// intentionally NOT behind the automated_scoring gate.
+export async function calculateDataScore(subjectType: TrustSubjectType, subjectId: string): Promise<DataScoreResult> {
+  const rows = await query<{
+    field_name: string
+    status: string
+    observed_at: string | null
+    valid_until: string | null
+    human_reviewed: boolean | null
+    object_hash: string | null
+    reliability: string | number | null
+  }>(
+    `SELECT f.field_name, f.status, e.observed_at, e.valid_until, e.human_reviewed, e.object_hash, s.reliability
+       FROM trust_fact_nodes f
+       JOIN trust_evidence_nodes e ON e.id = f.evidence_id
+       LEFT JOIN trust_source_registry s ON s.id = e.source_id
+      WHERE f.subject_type = $1 AND f.subject_id = $2
+        AND f.status IN ('ACTIVE', 'CONFIRMED', 'REVISED')`,
+    [subjectType, subjectId]
+  )
+
+  const weights = { clarity: 0.2, completeness: 0.2, recency: 0.2, consistency: 0.2, verifiability: 0.2 }
+  const empty = { clarity: 0, completeness: 0, recency: 0, consistency: 0, verifiability: 0 }
+  if (rows.length === 0) {
+    return { score: 0, modelVersion: 'data-score-pilot-1.0', dimensions: empty, weights, factCount: 0 }
+  }
+
+  const now = Date.now()
+  const RECENCY_WINDOW_MS = 180 * 24 * 60 * 60 * 1000
+  const expected = DATA_SCORE_EXPECTED_FIELDS[subjectType] ?? []
+
+  const clarity = rows.reduce((a, r) => a + (r.reliability != null ? Number(r.reliability) : 0), 0) / rows.length
+  const present = new Set(rows.map((r) => r.field_name))
+  const completeness = expected.length
+    ? [...present].filter((f) => expected.includes(f)).length / expected.length
+    : present.size > 0 ? 1 : 0
+  const recency = rows.filter((r) => {
+    const notExpired = !r.valid_until || new Date(r.valid_until).getTime() > now
+    const observed = r.observed_at ? new Date(r.observed_at).getTime() : 0
+    return notExpired && observed > 0 && now - observed <= RECENCY_WINDOW_MS
+  }).length / rows.length
+  const consistency = rows.filter((r) => r.status !== 'REVISED').length / rows.length
+  const verifiability = rows.filter((r) => r.human_reviewed === true || Boolean(r.object_hash)).length / rows.length
+
+  const dimensions = { clarity, completeness, recency, consistency, verifiability }
+  const score = Math.round(
+    100 * (clarity * weights.clarity + completeness * weights.completeness + recency * weights.recency + consistency * weights.consistency + verifiability * weights.verifiability)
+  )
+  return { score, modelVersion: 'data-score-pilot-1.0', dimensions, weights, factCount: rows.length }
+}


### PR DESCRIPTION
calculateDataScore over the plan's 5 evidence-quality criteria (출처명확성·완전성·최신성·일관성·검증가능성; equal pilot weights). GET /api/v1/data-score (self, ungated) + DataScoreCard on the trust center. 🤖 Generated with [Claude Code](https://claude.com/claude-code)