### PR TITLE
feat(auth): show only configured social providers

### DIFF
--- a/app/api/auth/providers/route.ts
+++ b/app/api/auth/providers/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { getEnabledProviders } from '@/lib/oauth'
+
+// GET /api/auth/providers — which social providers are configured (client id set),
+// so the login/signup UI only shows working buttons.
+export async function GET() {
+  return NextResponse.json({ providers: getEnabledProviders() })
+}

--- a/components/auth/social-login-buttons.tsx
+++ b/components/auth/social-login-buttons.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 
 interface SocialLoginButtonsProps {
@@ -8,10 +9,21 @@ interface SocialLoginButtonsProps {
 
 export function SocialLoginButtons({ mode }: SocialLoginButtonsProps) {
   const label = mode === 'login' ? '로그인' : '가입'
+  const [enabled, setEnabled] = useState<string[] | null>(null)
+
+  useEffect(() => {
+    fetch('/api/auth/providers')
+      .then((r) => (r.ok ? r.json() : { providers: [] }))
+      .then((d) => setEnabled(Array.isArray(d?.providers) ? d.providers : []))
+      .catch(() => setEnabled([]))
+  }, [])
 
   const handleSocial = (provider: string) => {
     window.location.href = `/api/auth/social/${provider}`
   }
+
+  // Until we know (or if none are configured), render nothing — no broken buttons.
+  if (!enabled || enabled.length === 0) return null
 
   return (
     <div className="space-y-3">
@@ -24,42 +36,48 @@ export function SocialLoginButtons({ mode }: SocialLoginButtonsProps) {
         </div>
       </div>
 
-      <Button
-        type="button"
-        variant="outline"
-        className="w-full bg-[#FEE500] text-[#191919] border-[#FEE500] hover:bg-[#FDD800] hover:border-[#FDD800]"
-        onClick={() => handleSocial('kakao')}
-      >
-        <svg viewBox="0 0 24 24" className="w-5 h-5 mr-2" fill="currentColor">
-          <path d="M12 3C6.48 3 2 6.36 2 10.5c0 2.63 1.76 4.96 4.42 6.3l-1.1 4.08c-.1.36.3.65.6.44l4.73-3.15c.44.05.89.08 1.35.08 5.52 0 10-3.36 10-7.5S17.52 3 12 3z" />
-        </svg>
-        카카오로 {label}
-      </Button>
+      {enabled.includes('kakao') && (
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full bg-[#FEE500] text-[#191919] border-[#FEE500] hover:bg-[#FDD800] hover:border-[#FDD800]"
+          onClick={() => handleSocial('kakao')}
+        >
+          <svg viewBox="0 0 24 24" className="w-5 h-5 mr-2" fill="currentColor">
+            <path d="M12 3C6.48 3 2 6.36 2 10.5c0 2.63 1.76 4.96 4.42 6.3l-1.1 4.08c-.1.36.3.65.6.44l4.73-3.15c.44.05.89.08 1.35.08 5.52 0 10-3.36 10-7.5S17.52 3 12 3z" />
+          </svg>
+          카카오로 {label}
+        </Button>
+      )}
 
-      <Button
-        type="button"
-        variant="outline"
-        className="w-full bg-[#03C75A] text-white border-[#03C75A] hover:bg-[#02b351] hover:border-[#02b351]"
-        onClick={() => handleSocial('naver')}
-      >
-        <span className="font-bold text-lg mr-2">N</span>
-        네이버로 {label}
-      </Button>
+      {enabled.includes('naver') && (
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full bg-[#03C75A] text-white border-[#03C75A] hover:bg-[#02b351] hover:border-[#02b351]"
+          onClick={() => handleSocial('naver')}
+        >
+          <span className="font-bold text-lg mr-2">N</span>
+          네이버로 {label}
+        </Button>
+      )}
 
-      <Button
-        type="button"
-        variant="outline"
-        className="w-full"
-        onClick={() => handleSocial('google')}
-      >
-        <svg viewBox="0 0 24 24" className="w-5 h-5 mr-2">
-          <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
-          <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-          <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-          <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-        </svg>
-        구글로 {label}
-      </Button>
+      {enabled.includes('google') && (
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full"
+          onClick={() => handleSocial('google')}
+        >
+          <svg viewBox="0 0 24 24" className="w-5 h-5 mr-2">
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+          </svg>
+          구글로 {label}
+        </Button>
+      )}
     </div>
   )
 }

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -40,6 +40,15 @@ export function getOAuthConfig(provider: AuthProvider): OAuthConfig {
   return providers[provider]()
 }
 
+/** A provider is usable only if its client id is configured. */
+export function isProviderEnabled(provider: AuthProvider): boolean {
+  return Boolean(getOAuthConfig(provider).clientId)
+}
+
+export function getEnabledProviders(): AuthProvider[] {
+  return (Object.keys(providers) as AuthProvider[]).filter(isProviderEnabled)
+}
+
 function getRedirectUri(provider: AuthProvider): string {
   const base = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'
   return `${base}/api/auth/social/${provider}/callback`


### PR DESCRIPTION
Render social buttons only for providers with a configured client id (GET /api/auth/providers). No broken buttons; with only Kakao set up, only Kakao shows. 🤖 Generated with [Claude Code](https://claude.com/claude-code)